### PR TITLE
The healthcheck should be nil if the port is nil

### DIFF
--- a/pkg/cloud-controller-manager/loadBalancer.go
+++ b/pkg/cloud-controller-manager/loadBalancer.go
@@ -260,6 +260,8 @@ func extractHealthCheck(svc *v1.Service) (*lbv1.HeathCheck, error) {
 	}
 	if port != nil {
 		healthCheck.Port = *port
+	} else {
+		return nil, nil
 	}
 
 	// successThreshold


### PR DESCRIPTION
Related issue:
https://github.com/harvester/harvester/issues/2041

Test plan:
- Deploy a guest cluster enabling harvester cloud provider
- Create an Nginx deployment and the related load balancer service disabling health check.