### PR TITLE
fix: add generate support for darwin

### DIFF
--- a/deploy/generate_addon.sh
+++ b/deploy/generate_addon.sh
@@ -152,7 +152,11 @@ echo "########## cloud config ############"
 cat ${KUBECFG_FILE_NAME}
 echo
 echo "########## cloud-init user data ############"
-KUBECONFIG_B64=$(base64 -w 0 < "${KUBECFG_FILE_NAME}")
+if [[ $OSTYPE == 'darwin'* ]]; then
+  KUBECONFIG_B64=$(base64 -b 0 < "${KUBECFG_FILE_NAME}")
+else
+  KUBECONFIG_B64=$(base64 -w 0 < "${KUBECFG_FILE_NAME}")
+fi
 cat <<EOF
 write_files:
 - encoding: b64


### PR DESCRIPTION
**Description:**
When running `bash deploy/generate_addon.sh test default` on Mac OS., it will report
```console
########## cloud-init user data ############
base64: invalid option -- w
```

**Solution:**
add generate script support for darwin