### PR TITLE
Add disable-vmi-controller option and fix 4459

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ func main() {
 	controllerInitializers := app.DefaultInitFuncConstructors
 
 	fss := cliflag.NamedFlagSets{}
+	harv := fss.FlagSet("harvester")
+	harv.BoolVar(&ccm.DisableVMIController, "disable-vmi-controller", ccm.DisableVMIController,
+		"The disable-vmi-controller will disable sync topology to nodes and not affect the custom cluster.")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, fss, wait.NeverStop)
 


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester/issues/4459
https://github.com/harvester/harvester/issues/4432

**Solution:**
- Add a disable-vmi-controller option to stop the node topology sync.
  - Use the cloud provider package's parameter `additionalFlags` to add the `--disable-vmi-controller` option.
  - The defect is after performing `cloud-provider --help`, it doesn't show the `--disable-vmi-controller` option.
- Fix the logic for getting node.
  - Get the guest node through the VMI name.
  - Return nil if not found, no more errors returns.

**Related Issue:**
https://github.com/harvester/harvester/issues/4459
https://github.com/harvester/harvester/issues/4432

**Test plan:**

1. Set `topology.kubernetes.io/zone` label for each harvester node. The value must be different.
2. Provide two guest clusters of rke2 in the same namespaces.
3. Check the cloud provider container log of the guest cluster. There are "not found" errors.
4. Edit the cloud provider deployment configuration and add the option `--disable-vmi-controller=true` to the arguments.
5. Check the cloud provider container log of the guest cluster. There is no "not found" error.
