### PR TITLE
fix: use vm name to get vmi

### DIFF
--- a/pkg/cloud-controller-manager/instance.go
+++ b/pkg/cloud-controller-manager/instance.go
@@ -50,7 +50,7 @@ func (i *instanceManager) InstanceMetadata(ctx context.Context, node *v1.Node) (
 		ProviderID: ProviderName + "://" + string(vm.UID),
 	}
 
-	vmi, err := i.vmiClient.Get(i.namespace, node.Name, metav1.GetOptions{})
+	vmi, err := i.vmiClient.Get(i.namespace, vm.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return meta, nil

--- a/pkg/controller/virtualmachineinstance/controller.go
+++ b/pkg/controller/virtualmachineinstance/controller.go
@@ -40,6 +40,7 @@ func Register(
 		restClient:     restClient,
 		kubevirtClient: kubevirtClient,
 		nodeToVMName:   nodeToVMName,
+		namespace:      namespace,
 	}
 	vmis.OnChange(ctx, vmiControllerName, handler.OnVmiChanged)
 }


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/4947

### Test steps

1. Follow https://docs.harvesterhci.io/v1.2/rancher/cloud-provider#deploying-to-the-k3s-cluster-with-harvester-node-driver-experimental to create a RKE2 cluster.
  1-1. For Helm chart, use version `v0.2.4`.
  1-2. Set `hostname` in the cloud-config.
2. After cluster is up, it can't finish. Use the image from current branch to replace kube-system/harvester-cloud-provider. You may need to delete old harvester-cloud-provider pod manually, because it has anti-affinity.
3. The cluster should be up.