### PR TITLE
Use default namespace if it's empty

### DIFF
--- a/pkg/cloud-controller-manager/ccm.go
+++ b/pkg/cloud-controller-manager/ccm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/wrangler/pkg/kubeconfig"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/rancher/wrangler/pkg/start"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
@@ -67,6 +68,9 @@ func newCloudProvider(reader io.Reader) (cloudprovider.Interface, error) {
 	}
 
 	namespace := rawConfig.Contexts[rawConfig.CurrentContext].Namespace
+	if namespace == "" {
+		namespace = corev1.NamespaceDefault
+	}
 
 	localCfg, err := kubeconfig.GetNonInteractiveClientConfig(os.Getenv("KUBECONFIG")).ClientConfig()
 	if err != nil {

--- a/pkg/controller/virtualmachineinstance/controller.go
+++ b/pkg/controller/virtualmachineinstance/controller.go
@@ -42,6 +42,10 @@ func Register(
 		nodeToVMName:   nodeToVMName,
 		namespace:      namespace,
 	}
+	logrus.WithFields(logrus.Fields{
+		"controller": vmiControllerName,
+		"namespace":  namespace,
+	}).Info("start watching virtual machine instance")
 	vmis.OnChange(ctx, vmiControllerName, handler.OnVmiChanged)
 }
 
@@ -63,10 +67,18 @@ func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance)
 	// only handle the migration completed vmi
 	if vmi == nil || vmi.DeletionTimestamp != nil ||
 		vmi.Annotations == nil || vmi.Namespace != h.namespace || !isMigrationCompleted(vmi) {
+		logrus.WithFields(logrus.Fields{
+			"namespace": vmi.Namespace,
+			"name":      vmi.Name,
+		}).Info("skip processing virtual machine instance")
 		return vmi, nil
 	}
 
 	if creator := vmi.Labels[builder.LabelKeyVirtualMachineCreator]; creator != virtualmachine.VirtualMachineCreatorNodeDriver {
+		logrus.WithFields(logrus.Fields{
+			"namespace": vmi.Namespace,
+			"name":      vmi.Name,
+		}).Info("skip processing virtual machine instance")
 		return vmi, nil
 	}
 


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/6098

#### Using manual install
1. Prepare the terraform rancher `provider.tf` file 
2. Get the kubeconfig file of Harvester and place in the local path 
3. Update the `provider.tf` file with the correct value 
  [providers.tf.txt](https://github.com/user-attachments/files/16052288/providers.tf.txt)
4. Execute following command to trigger terraform to provision RKE2 cluster from Rancer
    ```
    $ terraform init
    $ terraform plan
    $ terraform apply
    ```
5. When RKE2 is stuck in provisioning, get into the server and replace deployment `kube-system/harvester-cloud-provider` image with `frankyang/harvester-cloud-provider:4e1e2347-amd64`.
5.  Check the RKE2 cluster state
