### PR TITLE
chore: bump bci image to 15.6

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.suse.com/bci/bci-minimal:15.5
+FROM registry.suse.com/bci/bci-minimal:15.6
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
Related issue: harvester/harvester#6568