### PR TITLE
[WIP] Check and ensure cluster name and add support for multi networks

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,28 +34,28 @@ func main() {
 
 	fss := cliflag.NamedFlagSets{}
 	harv := fss.FlagSet("harvester")
-	harv.BoolVar(&cfg.DisableVMIController, utils.FlagDisableVmiController, false,
+	harv.BoolVar(&cfg.GetConfig().DisableVMIController, utils.FlagDisableVmiController, false,
 		"Disable sync topology to nodes and not affect the custom cluster.")
 
-	harv.StringVar(&cfg.ManagementNetwork, utils.FlagManagementNetwork, "",
+	harv.StringVar(&cfg.GetConfig().ManagementNetwork, utils.FlagManagementNetwork, "",
 		"Define the Harvester network name (e.g., 'default/vlan-100'). The provider will fetch node-ip and "+
 			"allocate loadbalancer-ip from the VMI interface (guest cluster node) associated with this network.")
 
-	harv.StringVar(&cfg.NodeIPCIDR, utils.FlagNodeIPCIDR, "",
+	harv.StringVar(&cfg.GetConfig().NodeIPCIDR, utils.FlagNodeIPCIDR, "",
 		"Comma-separated list of CIDRs to filter node IPs (e.g., '192.168.122.0/24,2001:db8::/64'). "+
 			"When used with --management-network, it further refines which IPs on that specific interface are selected. "+
 			"Used to avoid non-deterministic guessing in multi-NIC/multi-IP setups.")
 
-	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, utils.FlagAllowSpecifyLoadbalancerNetwork, false,
+	harv.BoolVar(&cfg.GetConfig().AllowSpecifyLoadBalancerNetwork, utils.FlagAllowSpecifyLoadbalancerNetwork, false,
 		"Allow loadbalancer to use user input annotation to specify the target network, otherwise the target network is always refetched. (default false)")
 
-	harv.BoolVar(&cfg.ShowFullHelpOnError, utils.FlagShowFullHelpOnError, false,
+	harv.BoolVar(&cfg.GetConfig().ShowFullHelpOnError, utils.FlagShowFullHelpOnError, false,
 		"Show the full help menu and flag list will be displayed if a configuration error occurs at startup. (default false)")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, map[string]string{}, fss, wait.NeverStop)
 
 	// Check if we should silence the framework's verbose help output
-	utils.CheckFlagShowFullHelpOnError(command)
+	utils.CheckFlagShowFullHelpOnError(command, cfg.GetConfig())
 
 	// Set static flags for which we know the values.
 	command.Flags().VisitAll(func(fl *pflag.Flag) {
@@ -90,7 +90,7 @@ func main() {
 	// Wrap the framework's RunE with our custom configuration sync and validation
 	originalRunE := command.RunE
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := utils.SyncAndValidateHarvesterConfig(cmd); err != nil {
+		if err := utils.SyncAndValidateHarvesterConfig(cmd, cfg.GetConfig()); err != nil {
 			return err
 		}
 		if originalRunE == nil {
@@ -101,7 +101,7 @@ func main() {
 
 	if err := command.Execute(); err != nil {
 		// Pass the error, the value of your custom flag, and the command object
-		utils.HandleStartupError(err)
+		utils.HandleStartupError(cfg.GetConfig(), err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 		"The management-network will define the management network of the cluster, otherwise it selects the first network.")
 
 	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, "allow-specify-load-balancer-network", false,
-		"The allow-specify-load-balancer-network will allow loadbalancer to use user input annotation to specifiy the target network, otherwise the target network is alwasy refetched.")
+		"The allow-specify-load-balancer-network will allow load balancer to use user input annotation to specify the target network, otherwise the target network is always refetched.")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, map[string]string{}, fss, wait.NeverStop)
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ import (
 )
 
 func main() {
+	utils.BootstrapLogrus()
+
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
@@ -38,7 +40,7 @@ func main() {
 	harv.BoolVar(&cfg.DisableVMIController, utils.FlagDisableVmiController, false,
 		"Disable sync topology to nodes and not affect the custom cluster.")
 
-	harv.StringVar(&cfg.ManagementNetwork, utils.FlagMgmtNetwork, "",
+	harv.StringVar(&cfg.ManagementNetwork, utils.FlagManagementNetwork, "",
 		"Define the management network of the cluster, otherwise it selects the first network.")
 
 	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, utils.FlagAllowSpecifyLoadbalancerNetwork, false,
@@ -139,16 +141,60 @@ func main() {
 // We log these values clearly at boot time to allow for immediate verification
 // of the runtime configuration in production logs.
 func syncAndValidateHarvesterConfig(cmd *cobra.Command) error {
-	cfg.ClusterName, _ = cmd.Flags().GetString(utils.FlagClusterName)
-	cfg.ManagementNetwork, _ = cmd.Flags().GetString(utils.FlagMgmtNetwork)
-	cfg.DisableVMIController, _ = cmd.Flags().GetBool(utils.FlagDisableVmiController)
-	cfg.AllowSpecifyLoadBalancerNetwork, _ = cmd.Flags().GetBool(utils.FlagAllowSpecifyLoadbalancerNetwork)
+	flags := cmd.Flags()
 
+	// Helper to catch internal registry errors (e.g. flag name typos in code)
+	// If GetString/GetBool fails, it means the flag wasn't registered properly.
+	getStr := func(name string) string {
+		val, err := flags.GetString(name)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: flag %q not registered: %v", name, err))
+		}
+		return val
+	}
+	getBool := func(name string) bool {
+		val, err := flags.GetBool(name)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: flag %q not registered: %v", name, err))
+		}
+		return val
+	}
+	getStrSlice := func(name string) []string {
+		val, err := flags.GetStringSlice(name)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: flag %q not registered as stringSlice: %v", name, err))
+		}
+		return val
+	}
+
+	// 1. Sync values from flags
+	cfg.ClusterName = getStr(utils.FlagClusterName)
+	cfg.ManagementNetwork = getStr(utils.FlagManagementNetwork)
+	cfg.DisableVMIController = getBool(utils.FlagDisableVmiController)
+	cfg.AllowSpecifyLoadBalancerNetwork = getBool(utils.FlagAllowSpecifyLoadbalancerNetwork)
+	cfg.ShowFullHelpOnError = getBool(utils.FlagShowFullHelpOnError)
+
+	// it is required to be customized via chart, hence show the value
+	controllerSlice := getStrSlice(utils.FlagCloudProviderControllers)
+	cfg.CloudProviderControllers = strings.Join(controllerSlice, ",")
+
+	// 2. Validate ClusterName
 	if cfg.ClusterName == "" || cfg.ClusterName == utils.DefaultGuestClusterName {
-		logrus.Warnf("%s WARNING: the flag --%s=%s is using an empty or default value (%q). A unique cluster name is "+
-			"required for remote systems to identify this cluster in multi-cluster "+
-			"environments. This may cause resource collisions.",
-			utils.HarvesterCloudProvider, utils.FlagClusterName, cfg.ClusterName, utils.DefaultGuestClusterName)
+		logrus.Warnf("%s WARNING: the flag --%s is using an empty or default value (current value: %q). "+
+			"A unique cluster name is required for remote systems to identify this cluster. "+
+			"This may cause resource collisions.",
+			utils.HarvesterCloudProvider, utils.FlagClusterName, cfg.ClusterName)
+	}
+
+	// 3. Validate and Normalize Network
+	if cfg.ManagementNetwork != "" {
+		normalized, err := utils.NormalizeNetworkName(utils.NetworkTypeManagement, cfg.ManagementNetwork)
+		if err != nil {
+			logrus.Errorf("The input is invalid: %v, the value is dropped and use the default value (empty)", err)
+			cfg.ManagementNetwork = ""
+		} else {
+			cfg.ManagementNetwork = normalized
+		}
 	}
 
 	logrus.Infof("%s effective configurations: %s", utils.HarvesterCloudProvider, cfg.CurrentConfigString())
@@ -195,10 +241,6 @@ func handleStartupError(err error) {
 	// Visual boundary to separate the error from standard container logs
 	logrus.Errorf("=============================================================================================")
 	logrus.Errorf("FATAL: %s failed to start", utils.HarvesterCloudProvider)
-
-	// Log the exact raw arguments received by the OS
-	// This is the ultimate "truth" for debugging Helm/Shell injection issues
-	logrus.Errorf("Raw arguments: %v", os.Args)
 
 	// Detect flag-related errors (typos, unsupported flags, etc.)
 	isFlagError := strings.Contains(errStr, "unknown flag") ||

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -41,7 +38,13 @@ func main() {
 		"Disable sync topology to nodes and not affect the custom cluster.")
 
 	harv.StringVar(&cfg.ManagementNetwork, utils.FlagManagementNetwork, "",
-		"Define the management network of the cluster, otherwise it selects the first network.")
+		"Define the Harvester network name (e.g., 'default/vlan-100'). The provider will fetch node-ip and "+
+			"allocate loadbalancer-ip from the VMI interface (guest cluster node) associated with this network.")
+
+	harv.StringVar(&cfg.NodeIPCIDR, utils.FlagNodeIPCIDR, "",
+		"Comma-separated list of CIDRs to filter node IPs (e.g., '192.168.122.0/24,2001:db8::/64'). "+
+			"When used with --management-network, it further refines which IPs on that specific interface are selected. "+
+			"Used to avoid non-deterministic guessing in multi-NIC/multi-IP setups.")
 
 	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, utils.FlagAllowSpecifyLoadbalancerNetwork, false,
 		"Allow loadbalancer to use user input annotation to specify the target network, otherwise the target network is always refetched. (default false)")
@@ -52,7 +55,7 @@ func main() {
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, map[string]string{}, fss, wait.NeverStop)
 
 	// Check if we should silence the framework's verbose help output
-	configureErrorReporting(command)
+	utils.CheckFlagShowFullHelpOnError(command)
 
 	// Set static flags for which we know the values.
 	command.Flags().VisitAll(func(fl *pflag.Flag) {
@@ -87,7 +90,7 @@ func main() {
 	// Wrap the framework's RunE with our custom configuration sync and validation
 	originalRunE := command.RunE
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := syncAndValidateHarvesterConfig(cmd); err != nil {
+		if err := utils.SyncAndValidateHarvesterConfig(cmd); err != nil {
 			return err
 		}
 		if originalRunE == nil {
@@ -98,172 +101,8 @@ func main() {
 
 	if err := command.Execute(); err != nil {
 		// Pass the error, the value of your custom flag, and the command object
-		handleStartupError(err)
+		utils.HandleStartupError(err)
 	}
-}
-
-// syncAndValidateHarvesterConfig bridges the gap between the K8s framework and Harvester needs.
-//
-// WHY:
-// The command flags are registered and processed by the underlying 'cloud-provider'
-// framework rather than our direct logic. The framework does not expose these
-// flags directly to the entire application; they are typically passed only to
-// specific plugins as needed. To log or verify these values globally before
-// the provider starts, this manual fetch is the most reliable method.
-//
-// CRITICALITY (Cluster Identity):
-// A unique 'cluster-name' is critical in multi-cluster management systems. If
-// left as the default "kubernetes", remote systems cannot distinguish which
-// cluster is requesting resources (like LoadBalancer IPs), leading to identity
-// collisions.
-//
-// DEPLOYMENT NOTE:
-//
-//   - Direct Deployment: Ensure container args include "--cluster-name=a-unique-name".
-//
-//   - Helm Chart Deployment: Ensure the following configuration is set (which
-//     is eventually converted into the deployment container args):
-//
-//     rkeConfig:
-//     chartValues:
-//     harvester-cloud-provider:
-//     global:
-//     cattle:
-//     clusterName: a-unique-name
-//
-// HOW:
-// We actively fetch them here via RunE to ensure our global configuration is
-// synchronized. This initialization is thread-safe because the various controller
-// loops and plugins have not been started yet; we are capturing the finalized
-// state before the framework branches into multi-threaded execution.
-//
-// TROUBLESHOOTING:
-// We log these values clearly at boot time to allow for immediate verification
-// of the runtime configuration in production logs.
-func syncAndValidateHarvesterConfig(cmd *cobra.Command) error {
-	flags := cmd.Flags()
-
-	// Helper to catch internal registry errors (e.g. flag name typos in code)
-	// If GetString/GetBool fails, it means the flag wasn't registered properly.
-	getStr := func(name string) string {
-		val, err := flags.GetString(name)
-		if err != nil {
-			panic(fmt.Sprintf("internal error: flag %q not registered: %v", name, err))
-		}
-		return val
-	}
-	getBool := func(name string) bool {
-		val, err := flags.GetBool(name)
-		if err != nil {
-			panic(fmt.Sprintf("internal error: flag %q not registered: %v", name, err))
-		}
-		return val
-	}
-	getStrSlice := func(name string) []string {
-		val, err := flags.GetStringSlice(name)
-		if err != nil {
-			panic(fmt.Sprintf("internal error: flag %q not registered as stringSlice: %v", name, err))
-		}
-		return val
-	}
-
-	// 1. Sync values from flags
-	cfg.ClusterName = getStr(utils.FlagClusterName)
-	cfg.ManagementNetwork = getStr(utils.FlagManagementNetwork)
-	cfg.DisableVMIController = getBool(utils.FlagDisableVmiController)
-	cfg.AllowSpecifyLoadBalancerNetwork = getBool(utils.FlagAllowSpecifyLoadbalancerNetwork)
-	cfg.ShowFullHelpOnError = getBool(utils.FlagShowFullHelpOnError)
-
-	// it is required to be customized via chart, hence show the value
-	controllerSlice := getStrSlice(utils.FlagCloudProviderControllers)
-	cfg.CloudProviderControllers = strings.Join(controllerSlice, ",")
-
-	// 2. Validate ClusterName
-	if cfg.ClusterName == "" || cfg.ClusterName == utils.DefaultGuestClusterName {
-		logrus.Warnf("%s WARNING: the flag --%s is using an empty or default value (current value: %q). "+
-			"A unique cluster name is required for remote systems to identify this cluster. "+
-			"This may cause resource collisions.",
-			utils.HarvesterCloudProvider, utils.FlagClusterName, cfg.ClusterName)
-	}
-
-	// 3. Validate and Normalize Network
-	if cfg.ManagementNetwork != "" {
-		normalized, err := utils.NormalizeNetworkName(utils.NetworkTypeManagement, cfg.ManagementNetwork)
-		if err != nil {
-			logrus.Errorf("The input is invalid: %v, the value is dropped and use the default value (empty)", err)
-			cfg.ManagementNetwork = ""
-		} else {
-			cfg.ManagementNetwork = normalized
-		}
-	}
-
-	logrus.Infof("%s effective configurations: %s", utils.HarvesterCloudProvider, cfg.CurrentConfigString())
-	return nil
-}
-
-// configureErrorReporting determines if the user wants the standard, concise
-// or the full cloud-provider framework help dump.
-//
-// DEBUGGING TIP: If you need to see the full list of supported flags,
-// manually edit the deployment/statefulset and add the following argument:
-//
-//	args:
-//	  - --show-full-help-on-error=true
-//
-// This is intentionally not exposed in the standard Helm Chart to keep
-// the user interface clean and prevent accidentally flooding production logs.
-func configureErrorReporting(cmd *cobra.Command) {
-	showFullHelp := false
-	for _, arg := range os.Args {
-		// We check os.Args directly because this happens before cmd.Execute()
-		if arg == "--"+utils.FlagShowFullHelpOnError+"=true" || arg == "--"+utils.FlagShowFullHelpOnError {
-			showFullHelp = true
-			break
-		}
-	}
-
-	if !showFullHelp {
-		// Silence the massive help wall and internal Cobra error printing
-		// so we can provide our own high-signal troubleshooting logs.
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-	}
-	cfg.ShowFullHelpOnError = showFullHelp
-}
-
-// handleStartupError provides a clean, user-friendly exit when the application fails to start.
-// Since the harvester-cloud-provider Helm chart allows users to inject custom flags via '.Values.extraArgs',
-// it is essential to check if the failure is due to an unknown flag. This ensures users
-// get clear feedback regarding typos in their Helm configuration rather than a generic crash.
-func handleStartupError(err error) {
-	errStr := err.Error()
-
-	// Visual boundary to separate the error from standard container logs
-	logrus.Errorf("=============================================================================================")
-	logrus.Errorf("FATAL: %s failed to start", utils.HarvesterCloudProvider)
-
-	// Detect flag-related errors (typos, unsupported flags, etc.)
-	isFlagError := strings.Contains(errStr, "unknown flag") ||
-		strings.Contains(errStr, "flag provided but not defined") ||
-		strings.Contains(errStr, "bad flag syntax")
-
-	logrus.Errorf("Error detail: %v", err)
-
-	if isFlagError {
-		logrus.Errorf("Potential cause: invalid flag(s) detected.")
-		logrus.Errorf("Helm check: verify the list in '.Values.extraArgs' within your values.yaml.")
-		logrus.Errorf("Action: ensure flags use the '--name=value' format and are supported by this version.")
-
-		if !cfg.ShowFullHelpOnError {
-			logrus.Infof("Hint: set '--show-full-help-on-error=true' to see all valid flags in the logs.")
-		}
-	}
-
-	// other logic-based errors (RBAC, Network, API, etc.)
-	logrus.Errorf("=============================================================================================")
-
-	// Always exit with a non-zero code to trigger a Pod restart/error state
-	os.Exit(1)
 }
 
 func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovider.Interface {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -15,6 +20,7 @@ import (
 
 	ccm "github.com/harvester/harvester-cloud-provider/pkg/cloud-controller-manager"
 	cfg "github.com/harvester/harvester-cloud-provider/pkg/config"
+	"github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
 func main() {
@@ -29,16 +35,22 @@ func main() {
 
 	fss := cliflag.NamedFlagSets{}
 	harv := fss.FlagSet("harvester")
-	harv.BoolVar(&ccm.DisableVMIController, "disable-vmi-controller", ccm.DisableVMIController,
-		"The disable-vmi-controller will disable sync topology to nodes and not affect the custom cluster.")
+	harv.BoolVar(&cfg.DisableVMIController, utils.FlagDisableVmiController, false,
+		"Disable sync topology to nodes and not affect the custom cluster.")
 
-	harv.StringVar(&cfg.ManagementNetwork, "management-network", "",
-		"The management-network will define the management network of the cluster, otherwise it selects the first network.")
+	harv.StringVar(&cfg.ManagementNetwork, utils.FlagMgmtNetwork, "",
+		"Define the management network of the cluster, otherwise it selects the first network.")
 
-	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, "allow-specify-load-balancer-network", false,
-		"The allow-specify-load-balancer-network will allow load balancer to use user input annotation to specify the target network, otherwise the target network is always refetched.")
+	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, utils.FlagAllowSpecifyLoadbalancerNetwork, false,
+		"Allow loadbalancer to use user input annotation to specify the target network, otherwise the target network is always refetched. (default false)")
+
+	harv.BoolVar(&cfg.ShowFullHelpOnError, utils.FlagShowFullHelpOnError, false,
+		"Show the full help menu and flag list will be displayed if a configuration error occurs at startup. (default false)")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, map[string]string{}, fss, wait.NeverStop)
+
+	// Check if we should silence the framework's verbose help output
+	configureErrorReporting(command)
 
 	// Set static flags for which we know the values.
 	command.Flags().VisitAll(func(fl *pflag.Flag) {
@@ -70,9 +82,146 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if err := command.Execute(); err != nil {
-		os.Exit(1)
+	// Wrap the framework's RunE with our custom configuration sync and validation
+	originalRunE := command.RunE
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := syncAndValidateHarvesterConfig(cmd); err != nil {
+			return err
+		}
+		if originalRunE == nil {
+			return fmt.Errorf("the original runE command was nil, initialization failed")
+		}
+		return originalRunE(cmd, args)
 	}
+
+	if err := command.Execute(); err != nil {
+		// Pass the error, the value of your custom flag, and the command object
+		handleStartupError(err)
+	}
+}
+
+// syncAndValidateHarvesterConfig bridges the gap between the K8s framework and Harvester needs.
+//
+// WHY:
+// The command flags are registered and processed by the underlying 'cloud-provider'
+// framework rather than our direct logic. The framework does not expose these
+// flags directly to the entire application; they are typically passed only to
+// specific plugins as needed. To log or verify these values globally before
+// the provider starts, this manual fetch is the most reliable method.
+//
+// CRITICALITY (Cluster Identity):
+// A unique 'cluster-name' is critical in multi-cluster management systems. If
+// left as the default "kubernetes", remote systems cannot distinguish which
+// cluster is requesting resources (like LoadBalancer IPs), leading to identity
+// collisions.
+//
+// DEPLOYMENT NOTE:
+//
+//   - Direct Deployment: Ensure container args include "--cluster-name=a-unique-name".
+//
+//   - Helm Chart Deployment: Ensure the following configuration is set (which
+//     is eventually converted into the deployment container args):
+//
+//     rkeConfig:
+//     chartValues:
+//     harvester-cloud-provider:
+//     global:
+//     cattle:
+//     clusterName: a-unique-name
+//
+// HOW:
+// We actively fetch them here via RunE to ensure our global configuration is
+// synchronized. This initialization is thread-safe because the various controller
+// loops and plugins have not been started yet; we are capturing the finalized
+// state before the framework branches into multi-threaded execution.
+//
+// TROUBLESHOOTING:
+// We log these values clearly at boot time to allow for immediate verification
+// of the runtime configuration in production logs.
+func syncAndValidateHarvesterConfig(cmd *cobra.Command) error {
+	cfg.ClusterName, _ = cmd.Flags().GetString(utils.FlagClusterName)
+	cfg.ManagementNetwork, _ = cmd.Flags().GetString(utils.FlagMgmtNetwork)
+	cfg.DisableVMIController, _ = cmd.Flags().GetBool(utils.FlagDisableVmiController)
+	cfg.AllowSpecifyLoadBalancerNetwork, _ = cmd.Flags().GetBool(utils.FlagAllowSpecifyLoadbalancerNetwork)
+
+	if cfg.ClusterName == "" || cfg.ClusterName == utils.DefaultGuestClusterName {
+		logrus.Warnf("%s WARNING: the flag --%s=%s is using an empty or default value (%q). A unique cluster name is "+
+			"required for remote systems to identify this cluster in multi-cluster "+
+			"environments. This may cause resource collisions.",
+			utils.HarvesterCloudProvider, utils.FlagClusterName, cfg.ClusterName, utils.DefaultGuestClusterName)
+	}
+
+	logrus.Infof("%s effective configurations: %s", utils.HarvesterCloudProvider, cfg.CurrentConfigString())
+	return nil
+}
+
+// configureErrorReporting determines if the user wants the standard, concise
+// or the full cloud-provider framework help dump.
+//
+// DEBUGGING TIP: If you need to see the full list of supported flags,
+// manually edit the deployment/statefulset and add the following argument:
+//
+//	args:
+//	  - --show-full-help-on-error=true
+//
+// This is intentionally not exposed in the standard Helm Chart to keep
+// the user interface clean and prevent accidentally flooding production logs.
+func configureErrorReporting(cmd *cobra.Command) {
+	showFullHelp := false
+	for _, arg := range os.Args {
+		// We check os.Args directly because this happens before cmd.Execute()
+		if arg == "--"+utils.FlagShowFullHelpOnError+"=true" || arg == "--"+utils.FlagShowFullHelpOnError {
+			showFullHelp = true
+			break
+		}
+	}
+
+	if !showFullHelp {
+		// Silence the massive help wall and internal Cobra error printing
+		// so we can provide our own high-signal troubleshooting logs.
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+	}
+	cfg.ShowFullHelpOnError = showFullHelp
+}
+
+// handleStartupError provides a clean, user-friendly exit when the application fails to start.
+// Since the harvester-cloud-provider Helm chart allows users to inject custom flags via '.Values.extraArgs',
+// it is essential to check if the failure is due to an unknown flag. This ensures users
+// get clear feedback regarding typos in their Helm configuration rather than a generic crash.
+func handleStartupError(err error) {
+	errStr := err.Error()
+
+	// Visual boundary to separate the error from standard container logs
+	logrus.Errorf("=============================================================================================")
+	logrus.Errorf("FATAL: %s failed to start", utils.HarvesterCloudProvider)
+
+	// Log the exact raw arguments received by the OS
+	// This is the ultimate "truth" for debugging Helm/Shell injection issues
+	logrus.Errorf("Raw arguments: %v", os.Args)
+
+	// Detect flag-related errors (typos, unsupported flags, etc.)
+	isFlagError := strings.Contains(errStr, "unknown flag") ||
+		strings.Contains(errStr, "flag provided but not defined") ||
+		strings.Contains(errStr, "bad flag syntax")
+
+	logrus.Errorf("Error detail: %v", err)
+
+	if isFlagError {
+		logrus.Errorf("Potential cause: invalid flag(s) detected.")
+		logrus.Errorf("Helm check: verify the list in '.Values.extraArgs' within your values.yaml.")
+		logrus.Errorf("Action: ensure flags use the '--name=value' format and are supported by this version.")
+
+		if !cfg.ShowFullHelpOnError {
+			logrus.Infof("Hint: set '--show-full-help-on-error=true' to see all valid flags in the logs.")
+		}
+	}
+
+	// other logic-based errors (RBAC, Network, API, etc.)
+	logrus.Errorf("=============================================================================================")
+
+	// Always exit with a non-zero code to trigger a Pod restart/error state
+	os.Exit(1)
 }
 
 func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovider.Interface {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 
 	ccm "github.com/harvester/harvester-cloud-provider/pkg/cloud-controller-manager"
+	cfg "github.com/harvester/harvester-cloud-provider/pkg/config"
 )
 
 func main() {
@@ -30,6 +31,12 @@ func main() {
 	harv := fss.FlagSet("harvester")
 	harv.BoolVar(&ccm.DisableVMIController, "disable-vmi-controller", ccm.DisableVMIController,
 		"The disable-vmi-controller will disable sync topology to nodes and not affect the custom cluster.")
+
+	harv.StringVar(&cfg.ManagementNetwork, "management-network", "",
+		"The management-network will define the management network of the cluster, otherwise it selects the first network.")
+
+	harv.BoolVar(&cfg.AllowSpecifyLoadBalancerNetwork, "allow-specify-load-balancer-network", false,
+		"The allow-specify-load-balancer-network will allow loadbalancer to use user input annotation to specifiy the target network, otherwise the target network is alwasy refetched.")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, map[string]string{}, fss, wait.NeverStop)
 

--- a/pkg/cloud-controller-manager/annotation.go
+++ b/pkg/cloud-controller-manager/annotation.go
@@ -1,15 +1,41 @@
+// Package ccm contains cloud-controller-manager related constants.
+// Deprecated: This package is deprecated. Please use the "github.com/harvester/harvester-cloud-provider/pkg/utils" package instead.
 package ccm
 
+import (
+	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
+)
+
 const (
-	// Annotation key
-	prefix            = "cloudprovider.harvesterhci.io/"
-	KeyIPAM           = prefix + "ipam"
-	KeyNetwork        = prefix + "network"
-	KeyProject        = prefix + "project"
-	KeyNamespace      = prefix + "namespace"
-	KeyPrimaryService = prefix + "primary-service"
+	// prefix is the standard prefix for Harvester cloud provider annotations.
+	// Deprecated: use utils.HarvesterCloudProviderPrefix instead.
+	prefix = utils.HarvesterCloudProviderPrefix
 
-	KeyKubevipLoadBalancerIP = "kube-vip.io/loadbalancerIPs"
+	// KeyIPAM is the annotation key for IPAM configuration.
+	// Deprecated: use utils.KeyIPAM instead.
+	KeyIPAM = utils.KeyIPAM
 
-	KeyAdditionalInternalIPs = prefix + "additional-internal-ips"
+	// KeyNetwork is the annotation key for network selection.
+	// Deprecated: use utils.KeyNetwork instead.
+	KeyNetwork = utils.KeyNetwork
+
+	// KeyProject is the annotation key for project identification.
+	// Deprecated: use utils.KeyProject instead.
+	KeyProject = utils.KeyProject
+
+	// KeyNamespace is the annotation key for namespace identification.
+	// Deprecated: use utils.KeyNamespace instead.
+	KeyNamespace = utils.KeyNamespace
+
+	// KeyPrimaryService is the annotation key for identifying the primary service in shared IP scenarios.
+	// Deprecated: use utils.KeyPrimaryService instead.
+	KeyPrimaryService = utils.KeyPrimaryService
+
+	// KeyKubevipLoadBalancerIP is the annotation key for kube-vip load balancer IPs.
+	// Deprecated: use utils.KeyKubevipLoadBalancerIP instead.
+	KeyKubevipLoadBalancerIP = utils.KeyKubevipLoadBalancerIP
+
+	// KeyAdditionalInternalIPs is the annotation key for adding extra internal IPs to nodes.
+	// Deprecated: use utils.KeyAdditionalInternalIPs instead.
+	KeyAdditionalInternalIPs = utils.KeyAdditionalInternalIPs
 )

--- a/pkg/cloud-controller-manager/annotation.go
+++ b/pkg/cloud-controller-manager/annotation.go
@@ -9,7 +9,7 @@ import (
 const (
 	// prefix is the standard prefix for Harvester cloud provider annotations.
 	// Deprecated: use utils.HarvesterCloudProviderPrefix instead.
-	prefix = utils.HarvesterCloudProviderPrefix
+	// prefix = utils.HarvesterCloudProviderPrefix
 
 	// KeyIPAM is the annotation key for IPAM configuration.
 	// Deprecated: use utils.KeyIPAM instead.

--- a/pkg/cloud-controller-manager/ccm.go
+++ b/pkg/cloud-controller-manager/ccm.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	ctllb "github.com/harvester/harvester-load-balancer/pkg/generated/controllers/loadbalancer.harvesterhci.io"
 	ctlkubevirt "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io"
 	ctlcore "github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
@@ -113,6 +115,8 @@ func newCloudProvider(reader io.Reader) (cloudprovider.Interface, error) {
 		nodeToVMName: nodeToVMName,
 		namespace:    namespace,
 	}
+
+	logrus.Infof("New CloudProvider Harvester on namespace %s", namespace)
 
 	return cp, nil
 }

--- a/pkg/cloud-controller-manager/ccm.go
+++ b/pkg/cloud-controller-manager/ccm.go
@@ -128,7 +128,7 @@ func newCloudProvider(reader io.Reader) (cloudprovider.Interface, error) {
 func (c *CloudProvider) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	client := clientBuilder.ClientOrDie(ProviderName)
 
-	if !cfg.DisableVMIController {
+	if !cfg.GetConfig().DisableVMIController {
 		vmi.Register(
 			c.Context,
 			client,

--- a/pkg/cloud-controller-manager/ccm.go
+++ b/pkg/cloud-controller-manager/ccm.go
@@ -2,6 +2,7 @@ package ccm
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -53,6 +54,10 @@ func init() {
 }
 
 func newCloudProvider(reader io.Reader) (cloudprovider.Interface, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("can't init from an empty reader (io.Reader), check the --cloud-config to ensure it has a valid cloud-config")
+	}
+
 	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud-controller-manager/ccm.go
+++ b/pkg/cloud-controller-manager/ccm.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 	"kubevirt.io/client-go/kubecli"
 
+	cfg "github.com/harvester/harvester-cloud-provider/pkg/config"
 	vmi "github.com/harvester/harvester-cloud-provider/pkg/controller/virtualmachineinstance"
 )
 
@@ -29,8 +30,6 @@ const (
 
 	threadiness = 2
 )
-
-var DisableVMIController bool
 
 type CloudProvider struct {
 	localCoreFactory *ctlcore.Factory
@@ -129,7 +128,7 @@ func newCloudProvider(reader io.Reader) (cloudprovider.Interface, error) {
 func (c *CloudProvider) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	client := clientBuilder.ClientOrDie(ProviderName)
 
-	if !DisableVMIController {
+	if !cfg.DisableVMIController {
 		vmi.Register(
 			c.Context,
 			client,

--- a/pkg/cloud-controller-manager/instance.go
+++ b/pkg/cloud-controller-manager/instance.go
@@ -16,6 +16,8 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/api"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
 type instanceManager struct {
@@ -128,7 +130,7 @@ func getNodeAddresses(node *v1.Node, vmi *kubevirtv1.VirtualMachineInstance) []v
 
 // User may want to mark some IPs of the node also as internal
 func getAdditionalInternalIPs(node *v1.Node) ([]string, error) {
-	aiIPs, ok := node.Annotations[KeyAdditionalInternalIPs]
+	aiIPs, ok := node.Annotations[utils.KeyAdditionalInternalIPs]
 	if !ok {
 		return nil, nil
 	}

--- a/pkg/cloud-controller-manager/instance_test.go
+++ b/pkg/cloud-controller-manager/instance_test.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider/api"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
 const (
@@ -100,7 +102,7 @@ func Test_getNodeAddresses(t *testing.T) {
 					Name: nodeName,
 					Annotations: map[string]string{
 						api.AnnotationAlphaProvidedIPAddr: networkDefaultIP,
-						KeyAdditionalInternalIPs:          "[\"192.168.120.12\", \"192.168.120.11\"]", // match nothing
+						utils.KeyAdditionalInternalIPs:    "[\"192.168.120.12\", \"192.168.120.11\"]", // match nothing
 					},
 				},
 			},
@@ -165,7 +167,7 @@ func Test_getNodeAddresses(t *testing.T) {
 					Name: nodeName,
 					Annotations: map[string]string{
 						api.AnnotationAlphaProvidedIPAddr: networkDefaultIP,
-						KeyAdditionalInternalIPs:          "192.168.120.11", // not a valid []string converted JSON
+						utils.KeyAdditionalInternalIPs:    "192.168.120.11", // not a valid []string converted JSON
 					},
 				},
 			},
@@ -230,7 +232,7 @@ func Test_getNodeAddresses(t *testing.T) {
 					Name: nodeName,
 					Annotations: map[string]string{
 						api.AnnotationAlphaProvidedIPAddr: networkDefaultIP,
-						KeyAdditionalInternalIPs:          "[\"192.168.120.10\", \"192.168.120.11\"]",
+						utils.KeyAdditionalInternalIPs:    "[\"192.168.120.10\", \"192.168.120.11\"]",
 					},
 				},
 			},
@@ -295,7 +297,7 @@ func Test_getNodeAddresses(t *testing.T) {
 					Name: nodeName,
 					Annotations: map[string]string{
 						api.AnnotationAlphaProvidedIPAddr: networkDefaultIP,
-						KeyAdditionalInternalIPs:          "[\"192.168.120.10\", \"192.168.130.10\"]",
+						utils.KeyAdditionalInternalIPs:    "[\"192.168.120.10\", \"192.168.130.10\"]",
 					},
 				},
 			},

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 	pkgctllb "github.com/harvester/harvester-load-balancer/pkg/controller/loadbalancer"
 	ctllbv1 "github.com/harvester/harvester-load-balancer/pkg/generated/controllers/loadbalancer.harvesterhci.io/v1beta1"
@@ -18,6 +20,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/util/retry"
+
+	cfg "github.com/harvester/harvester-cloud-provider/pkg/config"
+	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
 const (
@@ -192,6 +197,14 @@ func (l *LoadBalancerManager) EnsureLoadBalancerDeleted(ctx context.Context, clu
 	return l.deleteLoadBalancer(clusterName, service)
 }
 
+// the clusterName is passed by framework, if cloud-provider-harvester is not initialized with a valid value
+// the framework injiects "kubernetes"
+func warnClusterName(name, clusterName string) {
+	if clusterName == "" || clusterName == utils.DefaultGuestClusterName {
+		logrus.Warnf("The cluster name is %s, it might cause failure when creating lb %s, ensure an unique name is set", clusterName, name)
+	}
+}
+
 func (l *LoadBalancerManager) createOrUpdateLoadBalancer(name, clusterName string, service *v1.Service) error {
 	lb, err := l.lbClient.Get(l.namespace, name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
@@ -200,12 +213,35 @@ func (l *LoadBalancerManager) createOrUpdateLoadBalancer(name, clusterName strin
 
 	newLB := l.constructLB(lb, service, name, clusterName)
 	if errors.IsNotFound(err) {
+		warnClusterName(name, clusterName)
 		_, err = l.lbClient.Create(newLB)
 	} else {
 		_, err = l.lbClient.Update(newLB)
 	}
 
 	return err
+}
+
+func patchLB(lb *lbv1.LoadBalancer) {
+	if lb == nil {
+		return
+	}
+	config := cfg.Get()
+	if config == nil {
+		return
+	}
+
+	// if user has specify the management network, carry it
+	if cfg.ManagementNetwork != "" {
+		lb.Labels[utils.LabelKeyGuestClusterManagementNetworkOnLB] = cfg.ManagementNetwork
+	} else {
+		delete(lb.Labels, utils.LabelKeyGuestClusterManagementNetworkOnLB)
+	}
+
+	// only keep cloudprovider.harvesterhci.io/lbNetwork if AllowSpecifyLoadBalancerNetwork is specified
+	if !cfg.AllowSpecifyLoadBalancerNetwork {
+		delete(lb.Labels, utils.LabelKeyGuestClusterNetworkNameOnLB)
+	}
 }
 
 func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.Service, name, clusterName string) *lbv1.LoadBalancer {
@@ -240,6 +276,8 @@ func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.
 	lb.Labels[clusterNameKey] = clusterName
 	lb.Labels[serviceNamespaceKey] = service.Namespace
 	lb.Labels[serviceNameKey] = service.Name
+
+	patchLB(lb)
 
 	ipam := lbv1.Pool
 	if ipamStr, ok := service.Annotations[KeyIPAM]; ok {

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -222,6 +222,16 @@ func (l *LoadBalancerManager) createOrUpdateLoadBalancer(name, clusterName strin
 	return err
 }
 
+// patchLB prepares the LoadBalancer resource by normalizing and prioritizing
+// network annotations.
+//
+// DESIGN PHILOSOPHY:
+// The Cloud Provider acts as a high-fidelity messenger. It tries its best to send
+// the most accurate and flexible request to the remote Harvester (lb-controller) by
+// validating formats and enforcing configuration hierarchies. However, the
+// final decision on resource placement and network existence remains with the
+// remote lb controller. This "Fail-Clear" approach ensures that
+// errors are actionable and traffic never flows to an unintended network.
 func patchLB(lb *lbv1.LoadBalancer) {
 	if lb == nil {
 		return
@@ -231,26 +241,46 @@ func patchLB(lb *lbv1.LoadBalancer) {
 		lb.Annotations = make(map[string]string)
 	}
 
-	// PRIORITY 1: Global Management Network (The Authority)
-	// This always takes precedence if set via the cloud-provider config.
+	// PRIORITY 1 (Highest): Per-LB User Specified Target Network
+	// This is an explicit override. If the user provides this and the global flag
+	// 'AllowSpecifyLoadBalancerNetwork' is true, this value takes precedence.
+	// Note: If the user provides a non-existent network, LB provisioning may fail;
+	// this is intentional to avoid placing traffic on the wrong network silently.
+	if cfg.AllowSpecifyLoadBalancerNetwork {
+		val, exists := lb.Annotations[utils.AnnotationKeyGuestClusterNetworkNameOnLB]
+		if exists {
+			target, err := utils.NormalizeNetworkName(utils.NetworkTypeLB, val)
+			if err != nil {
+				logrus.Warnf("LoadBalancer %s/%s: %v, the user input is stripped.", lb.Namespace, lb.Name, err)
+				delete(lb.Annotations, utils.AnnotationKeyGuestClusterNetworkNameOnLB)
+			} else {
+				lb.Annotations[utils.AnnotationKeyGuestClusterNetworkNameOnLB] = target
+			}
+		}
+	} else {
+		// If the master switch is off, strictly remove any user-provided network annotations.
+		delete(lb.Annotations, utils.AnnotationKeyGuestClusterNetworkNameOnLB)
+	}
+
+	// PRIORITY 2 (Medium): Global Management Network
+	// This acts as the authoritative default provided by the cloud-provider config.
+	// It is used if the user hasn't specified a valid override.
 	if cfg.ManagementNetwork != "" {
-		lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB] = cfg.ManagementNetwork
+		// Re-verifying the global config here ensures the annotation is always formatted correctly.
+		target, err := utils.NormalizeNetworkName(utils.NetworkTypeManagement, cfg.ManagementNetwork)
+		if err != nil {
+			logrus.Warnf("LoadBalancer %s/%s: global config %v, dropping annotation.", lb.Namespace, lb.Name, err)
+			delete(lb.Annotations, utils.AnnotationKeyGuestClusterManagementNetworkOnLB)
+		} else {
+			lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB] = target
+		}
 	} else {
 		delete(lb.Annotations, utils.AnnotationKeyGuestClusterManagementNetworkOnLB)
 	}
 
-	// PRIORITY 2: Per-LB User Specified Target Network
-	// This is an override, but it is strictly guarded by the global 'AllowSpecifyLoadBalancerNetwork' flag.
-	// only keep cloudprovider.harvesterhci.io/lbNetwork if AllowSpecifyLoadBalancerNetwork is specified
-	if !cfg.AllowSpecifyLoadBalancerNetwork {
-		// If not allowed globally, we strip the user's request to force the
-		// logic toward Priority 1 or the Priority 3 fallback.
-		delete(lb.Annotations, utils.AnnotationKeyGuestClusterNetworkNameOnLB)
-	}
-
-	// PRIORITY 3: Fallback (Implicit)
-	// If the logic reaching this, Harvester side LB finds both annotations missing, it will
-	// trigger the internal "look through and guess" iteration.
+	// PRIORITY 3 (Lowest): Fallback (Implicit)
+	// If both annotations are missing after the logic above, the Harvester-side
+	// LoadBalancer controller will trigger its internal fallback discovery logic.
 }
 
 func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.Service, name, clusterName string) *lbv1.LoadBalancer {

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -29,9 +29,9 @@ const (
 	retryTimes    = 10
 	retryInterval = time.Second
 
-	serviceNamespaceKey = prefix + "serviceNamespace"
-	serviceNameKey      = prefix + "serviceName"
-	clusterNameKey      = prefix + "cluster"
+	//serviceNamespaceKey = utils.HarvesterCloudProviderPrefix + "serviceNamespace"
+	//serviceNameKey      = utils.HarvesterCloudProviderPrefix + "serviceName"
+	//clusterNameKey      = utils.HarvesterCloudProviderPrefix + "cluster"
 
 	maxNameLength = 63
 	lenOfSuffix   = 8
@@ -99,7 +99,7 @@ func loadBalancerName(clusterName, serviceNamespace, serviceName, serviceUID str
 // if it's an invalid service, return error.
 // if it's not a secondary service, return nil.
 func (l *LoadBalancerManager) getPrimaryService(service *v1.Service) (*v1.Service, error) {
-	primary, ok := service.Annotations[KeyPrimaryService]
+	primary, ok := service.Annotations[utils.KeyPrimaryService]
 	if !ok {
 		return nil, nil
 	}
@@ -114,7 +114,7 @@ func (l *LoadBalancerManager) getPrimaryService(service *v1.Service) (*v1.Servic
 		return nil, fmt.Errorf("get service %s failed: %w", primary, err)
 	}
 
-	if primarySvc.Annotations[KeyPrimaryService] != "" {
+	if primarySvc.Annotations[utils.KeyPrimaryService] != "" {
 		return nil, fmt.Errorf("service %s is not a primary service", primary)
 	}
 
@@ -304,23 +304,23 @@ func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.
 	if lb.Annotations == nil {
 		lb.Annotations = make(map[string]string)
 	}
-	lb.Annotations[pkgctllb.AnnotationKeyNetwork] = service.Annotations[KeyNetwork]
-	lb.Annotations[pkgctllb.AnnotationKeyProject] = service.Annotations[KeyProject]
-	lb.Annotations[pkgctllb.AnnotationKeyNamespace] = service.Annotations[KeyNamespace]
+	lb.Annotations[pkgctllb.AnnotationKeyNetwork] = service.Annotations[utils.KeyNetwork]
+	lb.Annotations[pkgctllb.AnnotationKeyProject] = service.Annotations[utils.KeyProject]
+	lb.Annotations[pkgctllb.AnnotationKeyNamespace] = service.Annotations[utils.KeyNamespace]
 	lb.Annotations[pkgctllb.AnnotationKeyCluster] = clusterName
 
 	if lb.Labels == nil {
 		lb.Labels = make(map[string]string)
 	}
-	lb.Labels[clusterNameKey] = clusterName
-	lb.Labels[serviceNamespaceKey] = service.Namespace
-	lb.Labels[serviceNameKey] = service.Name
+	lb.Labels[utils.LBClusterNameKey] = clusterName
+	lb.Labels[utils.LBServiceNamespaceKey] = service.Namespace
+	lb.Labels[utils.LBClusterNameKey] = service.Name
 
 	// per global setting, patch the lb
 	patchLB(lb)
 
 	ipam := lbv1.Pool
-	if ipamStr, ok := service.Annotations[KeyIPAM]; ok {
+	if ipamStr, ok := service.Annotations[utils.KeyIPAM]; ok {
 		ipam = lbv1.IPAM(ipamStr)
 	}
 	lb.Spec.IPAM = ipam
@@ -358,7 +358,7 @@ func (l *LoadBalancerManager) retryUpdateService(service *v1.Service, serviceTyp
 }
 
 func isPrimaryServiceUpdatedWithIP(service *v1.Service, lbAddress, ip string) bool {
-	return service.Annotations != nil && service.Annotations[KeyKubevipLoadBalancerIP] == ip && lbAddress == ip && service.Labels != nil && service.Labels[KeyPrimaryService] == ""
+	return service.Annotations != nil && service.Annotations[utils.KeyKubevipLoadBalancerIP] == ip && lbAddress == ip && service.Labels != nil && service.Labels[utils.KeyPrimaryService] == ""
 }
 
 func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, service *v1.Service) error {
@@ -383,13 +383,13 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 	}
 
 	updatePrimaryServiceObject := func(serviceCopy *v1.Service, ip, primaryLabel string) {
-		if serviceCopy.Labels != nil && serviceCopy.Labels[KeyPrimaryService] != "" {
-			serviceCopy.Labels[KeyPrimaryService] = ""
+		if serviceCopy.Labels != nil && serviceCopy.Labels[utils.KeyPrimaryService] != "" {
+			serviceCopy.Labels[utils.KeyPrimaryService] = ""
 		}
 		if serviceCopy.Annotations == nil {
 			serviceCopy.Annotations = make(map[string]string)
 		}
-		serviceCopy.Annotations[KeyKubevipLoadBalancerIP] = ip
+		serviceCopy.Annotations[utils.KeyKubevipLoadBalancerIP] = ip
 	}
 
 	// the above waitForIP takes time, it has high chance to hit the `IsConflict` error like
@@ -398,7 +398,7 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 }
 
 func isSecondaryServiceUpdatedWithPrimary(secondary *v1.Service, ip, labelValue string) bool {
-	return secondary.Annotations != nil && secondary.Annotations[KeyKubevipLoadBalancerIP] == ip && secondary.Annotations[KeyIPAM] == "" && secondary.Labels != nil && secondary.Labels[KeyPrimaryService] == labelValue
+	return secondary.Annotations != nil && secondary.Annotations[utils.KeyKubevipLoadBalancerIP] == ip && secondary.Annotations[utils.KeyIPAM] == "" && secondary.Labels != nil && secondary.Labels[utils.KeyPrimaryService] == labelValue
 }
 
 func (l *LoadBalancerManager) updateSecondaryServiceLoadBalancerIP(ip string, primary, secondary *v1.Service) error {
@@ -415,10 +415,10 @@ func (l *LoadBalancerManager) updateSecondaryServiceLoadBalancerIP(ip string, pr
 			secondaryCopy.Annotations = make(map[string]string)
 		}
 		// add a label for easy filtering
-		secondaryCopy.Labels[KeyPrimaryService] = primaryLabel
+		secondaryCopy.Labels[utils.KeyPrimaryService] = primaryLabel
 		// update the annotations and kube-vip will update the service status load balancer
-		secondaryCopy.Annotations[KeyKubevipLoadBalancerIP] = ip
-		delete(secondaryCopy.Annotations, KeyIPAM)
+		secondaryCopy.Annotations[utils.KeyKubevipLoadBalancerIP] = ip
+		delete(secondaryCopy.Annotations, utils.KeyIPAM)
 	}
 
 	return l.retryUpdateService(secondary, "secondary", ip, labelValue, updateSecondaryServiceObject)
@@ -467,7 +467,7 @@ func (l *LoadBalancerManager) checkPortOverlap(primary, secondary *v1.Service) e
 	// TODO: Listing services filtered by primary service label could cause concurrency problem because the primary service
 	// label is added after this function is called. Some eligible services may not be listed.
 	svcs, err := l.localSvcCache.List(metav1.NamespaceAll, labels.Set(map[string]string{
-		KeyPrimaryService: primaryServiceLabelValue(primary),
+		utils.KeyPrimaryService: primaryServiceLabelValue(primary),
 	}).AsSelector())
 	if err != nil {
 		return fmt.Errorf("list service failed: %w", err)
@@ -495,7 +495,7 @@ func (l *LoadBalancerManager) checkSecondaryServicesBeforeDeleted(primary *v1.Se
 	// Listing services filtered by primary service label could cause concurrency problem because there may be secondary
 	// services added after this function is called and before the service is deleted.
 	svcs, err := l.localSvcCache.List(metav1.NamespaceAll, labels.Set(map[string]string{
-		KeyPrimaryService: primaryServiceLabelValue(primary),
+		utils.KeyPrimaryService: primaryServiceLabelValue(primary),
 	}).AsSelector())
 	if err != nil {
 		return err

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -226,22 +226,31 @@ func patchLB(lb *lbv1.LoadBalancer) {
 	if lb == nil {
 		return
 	}
-	config := cfg.Get()
-	if config == nil {
-		return
+
+	if lb.Annotations == nil {
+		lb.Annotations = make(map[string]string)
 	}
 
-	// if user has specify the management network, carry it
+	// PRIORITY 1: Global Management Network (The Authority)
+	// This always takes precedence if set via the cloud-provider config.
 	if cfg.ManagementNetwork != "" {
-		lb.Labels[utils.LabelKeyGuestClusterManagementNetworkOnLB] = cfg.ManagementNetwork
+		lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB] = cfg.ManagementNetwork
 	} else {
-		delete(lb.Labels, utils.LabelKeyGuestClusterManagementNetworkOnLB)
+		delete(lb.Annotations, utils.AnnotationKeyGuestClusterManagementNetworkOnLB)
 	}
 
+	// PRIORITY 2: Per-LB User Specified Target Network
+	// This is an override, but it is strictly guarded by the global 'AllowSpecifyLoadBalancerNetwork' flag.
 	// only keep cloudprovider.harvesterhci.io/lbNetwork if AllowSpecifyLoadBalancerNetwork is specified
 	if !cfg.AllowSpecifyLoadBalancerNetwork {
-		delete(lb.Labels, utils.LabelKeyGuestClusterNetworkNameOnLB)
+		// If not allowed globally, we strip the user's request to force the
+		// logic toward Priority 1 or the Priority 3 fallback.
+		delete(lb.Annotations, utils.AnnotationKeyGuestClusterNetworkNameOnLB)
 	}
+
+	// PRIORITY 3: Fallback (Implicit)
+	// If the logic reaching this, Harvester side LB finds both annotations missing, it will
+	// trigger the internal "look through and guess" iteration.
 }
 
 func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.Service, name, clusterName string) *lbv1.LoadBalancer {
@@ -277,6 +286,7 @@ func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.
 	lb.Labels[serviceNamespaceKey] = service.Namespace
 	lb.Labels[serviceNameKey] = service.Name
 
+	// per global setting, patch the lb
 	patchLB(lb)
 
 	ipam := lbv1.Pool

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -198,10 +198,10 @@ func (l *LoadBalancerManager) EnsureLoadBalancerDeleted(ctx context.Context, clu
 }
 
 // the clusterName is passed by framework, if cloud-provider-harvester is not initialized with a valid value
-// the framework injiects "kubernetes"
+// the framework injects "kubernetes"
 func warnClusterName(name, clusterName string) {
 	if clusterName == "" || clusterName == utils.DefaultGuestClusterName {
-		logrus.Warnf("The cluster name is %s, it might cause failure when creating lb %s, ensure an unique name is set", clusterName, name)
+		logrus.Warnf("The cluster name is %q, it might cause failure when creating lb %s, ensure a unique name is set", clusterName, name)
 	}
 }
 

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -246,7 +246,7 @@ func patchLB(lb *lbv1.LoadBalancer) {
 	// 'AllowSpecifyLoadBalancerNetwork' is true, this value takes precedence.
 	// Note: If the user provides a non-existent network, LB provisioning may fail;
 	// this is intentional to avoid placing traffic on the wrong network silently.
-	if cfg.AllowSpecifyLoadBalancerNetwork {
+	if cfg.GetConfig().AllowSpecifyLoadBalancerNetwork {
 		val, exists := lb.Annotations[utils.AnnotationKeyGuestClusterNetworkNameOnLB]
 		if exists {
 			target, err := utils.NormalizeNetworkName(utils.NetworkTypeLB, val)
@@ -265,9 +265,9 @@ func patchLB(lb *lbv1.LoadBalancer) {
 	// PRIORITY 2 (Medium): Global Management Network
 	// This acts as the authoritative default provided by the cloud-provider config.
 	// It is used if the user hasn't specified a valid override.
-	if cfg.ManagementNetwork != "" {
+	if cfg.GetConfig().ManagementNetwork != "" {
 		// Re-verifying the global config here ensures the annotation is always formatted correctly.
-		target, err := utils.NormalizeNetworkName(utils.NetworkTypeManagement, cfg.ManagementNetwork)
+		target, err := utils.NormalizeNetworkName(utils.NetworkTypeManagement, cfg.GetConfig().ManagementNetwork)
 		if err != nil {
 			logrus.Warnf("LoadBalancer %s/%s: global config %v, dropping annotation.", lb.Namespace, lb.Name, err)
 			delete(lb.Annotations, utils.AnnotationKeyGuestClusterManagementNetworkOnLB)

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -1,9 +1,17 @@
 package ccm
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cfg "github.com/harvester/harvester-cloud-provider/pkg/config"
 	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
@@ -36,8 +44,133 @@ func Test_getLoadBalancerName(t *testing.T) {
 			}
 		})
 	}
+}
 
-	warnClusterName("lb1", "") // a logrus warn is emited
+func Test_warnClusterName(t *testing.T) {
+	// 1. Setup a buffer to capture logs
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
 
-	warnClusterName("lb2", utils.DefaultGuestClusterName) // a logrus warn is emited
+	// 2. Ensure we reset logrus after the test
+	defer logrus.SetOutput(os.Stderr)
+
+	tests := []struct {
+		name        string
+		clusterName string
+		lbName      string
+		shouldWarn  bool
+	}{
+		{
+			name:        "Empty cluster name triggers warning",
+			clusterName: "",
+			lbName:      "lb1",
+			shouldWarn:  true,
+		},
+		{
+			name:        "Default cluster name triggers warning",
+			clusterName: utils.DefaultGuestClusterName,
+			lbName:      "lb2",
+			shouldWarn:  true,
+		},
+		{
+			name:        "Unique cluster name does not trigger warning",
+			clusterName: "production-cluster",
+			lbName:      "lb3",
+			shouldWarn:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset() // Clear logs from previous run
+
+			warnClusterName(tt.lbName, tt.clusterName)
+
+			hasWarning := strings.Contains(buf.String(), "ensure a unique name is set")
+			if hasWarning != tt.shouldWarn {
+				t.Errorf("Expected warning: %v, but got: %v. Log output: %s",
+					tt.shouldWarn, hasWarning, buf.String())
+			}
+		})
+	}
+}
+
+func Test_patchLB_Priority(t *testing.T) {
+	// Setup/Restore cfg logic here...
+
+	tests := []struct {
+		name                string
+		mgmtNetwork         string
+		allowSpecify        bool
+		initialAnnotations  map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:         "Priority 1 Enforced: Mgmt network exists",
+			mgmtNetwork:  "harvester-mgmt/vlan-100",
+			allowSpecify: true,
+			initialAnnotations: map[string]string{
+				// User tries to specify a custom one
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+			},
+			expectedAnnotations: map[string]string{
+				// Both are present, but your controller logic will read Mgmt first
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "harvester-mgmt/vlan-100",
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "user/vlan-200",
+			},
+		},
+		{
+			name:         "Priority 2 Stripped: User specified, but not allowed globally",
+			mgmtNetwork:  "",
+			allowSpecify: false,
+			initialAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+			},
+			expectedAnnotations: map[string]string{
+				// Result is empty -> Triggers Priority 3 (Fallback/Guess)
+			},
+		},
+		{
+			name:         "Priority 2 Allowed: User specified and allowed globally",
+			mgmtNetwork:  "",
+			allowSpecify: true,
+			initialAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+			},
+			expectedAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+			},
+		},
+		{
+			name:         "Legacy Case: No global config and no LB annotations",
+			mgmtNetwork:  "",    // No global flag set
+			allowSpecify: false, // Default/Legacy state
+			initialAnnotations: map[string]string{
+				"other-annotation": "stays-untouched",
+			},
+			expectedAnnotations: map[string]string{
+				"other-annotation": "stays-untouched",
+				// No new annotations added, none removed.
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.ManagementNetwork = tt.mgmtNetwork
+			cfg.AllowSpecifyLoadBalancerNetwork = tt.allowSpecify
+
+			lb := &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.initialAnnotations,
+				},
+			}
+
+			patchLB(lb)
+
+			if diff := cmp.Diff(tt.expectedAnnotations, lb.Annotations); diff != "" {
+				t.Errorf("patchLB() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -24,6 +24,7 @@ func Test_getLoadBalancerName(t *testing.T) {
 		{"case_3", args{"test", "default-default", "kube-system-rke2-ingress-nginx-controller", defaultUID}, "test-default-default-kube-system-rke2-ingress-nginx-con"},
 		{"case_4", args{"test", "default-default", "kube-system-rke2-ingress-nginx-co-abcd", defaultUID}, "test-default-default-kube-system-rke2-ingress-nginx-co-"},
 		{"case_5", args{"1test", "default-default", "kube-system-rke2-ingress-nginx-controller", defaultUID}, "a1test-default-default-kube-system-rke2-ingress-nginx-c"},
+		{"case_6", args{"kubernetes", "default-default", "kube-system-rke2-ingress-nginx-controller", defaultUID}, "kubernetes-default-default-kube-system-rke2-"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -33,4 +34,7 @@ func Test_getLoadBalancerName(t *testing.T) {
 			}
 		})
 	}
+
+	warnClusterName("lb1", "")                      // a logrus warn is emited
+	warnClusterName("lb2", defaultGuestClusterName) // a logrus warn is emited
 }

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -199,19 +199,17 @@ func Test_patchLB_Priority(t *testing.T) {
 		},
 	}
 
-	originalManagementNetwork := cfg.ManagementNetwork
-	originalAllowSpecifyLoadBalancerNetwork := cfg.AllowSpecifyLoadBalancerNetwork
-
-	defer func() {
-		cfg.ManagementNetwork = originalManagementNetwork
-		cfg.AllowSpecifyLoadBalancerNetwork = originalAllowSpecifyLoadBalancerNetwork
-	}()
+	originalConfig := *cfg.GetConfig()
+	restoreConfig := func() {
+		*cfg.GetConfig() = originalConfig
+	}
+	defer restoreConfig()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set global config state
-			cfg.ManagementNetwork = tt.mgmtNetwork
-			cfg.AllowSpecifyLoadBalancerNetwork = tt.allowSpecify
+			cfg.GetConfig().ManagementNetwork = tt.mgmtNetwork
+			cfg.GetConfig().AllowSpecifyLoadBalancerNetwork = tt.allowSpecify
 
 			lb := &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -3,6 +3,8 @@ package ccm
 import (
 	"strings"
 	"testing"
+
+	utils "github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
 const defaultUID = "d4b50d98-39ec-4d88-8098-36579de5db4a"
@@ -35,6 +37,7 @@ func Test_getLoadBalancerName(t *testing.T) {
 		})
 	}
 
-	warnClusterName("lb1", "")                      // a logrus warn is emited
-	warnClusterName("lb2", defaultGuestClusterName) // a logrus warn is emited
+	warnClusterName("lb1", "") // a logrus warn is emited
+
+	warnClusterName("lb2", utils.DefaultGuestClusterName) // a logrus warn is emited
 }

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -2,7 +2,6 @@ package ccm
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 
@@ -49,10 +48,10 @@ func Test_getLoadBalancerName(t *testing.T) {
 func Test_warnClusterName(t *testing.T) {
 	// 1. Setup a buffer to capture logs
 	var buf bytes.Buffer
+	originalOutput := logrus.StandardLogger().Out
 	logrus.SetOutput(&buf)
-
 	// 2. Ensure we reset logrus after the test
-	defer logrus.SetOutput(os.Stderr)
+	defer logrus.SetOutput(originalOutput)
 
 	tests := []struct {
 		name        string
@@ -96,8 +95,6 @@ func Test_warnClusterName(t *testing.T) {
 }
 
 func Test_patchLB_Priority(t *testing.T) {
-	// Setup/Restore cfg logic here...
-
 	tests := []struct {
 		name                string
 		mgmtNetwork         string
@@ -106,62 +103,120 @@ func Test_patchLB_Priority(t *testing.T) {
 		expectedAnnotations map[string]string
 	}{
 		{
-			name:         "Priority 1 Enforced: Mgmt network exists",
+			name:         "User Override: User input normalized and mgmt network added",
 			mgmtNetwork:  "harvester-mgmt/vlan-100",
 			allowSpecify: true,
 			initialAnnotations: map[string]string{
-				// User tries to specify a custom one
-				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "custom-vlan",
 			},
 			expectedAnnotations: map[string]string{
-				// Both are present, but your controller logic will read Mgmt first
+				// User input is normalized (bare name -> default/name)
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "default/custom-vlan",
 				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "harvester-mgmt/vlan-100",
-				utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "user/vlan-200",
 			},
 		},
 		{
-			name:         "Priority 2 Stripped: User specified, but not allowed globally",
+			name:         "User Override: Invalid user input stripped, mgmt network remains",
+			mgmtNetwork:  "harvester-mgmt/vlan-100",
+			allowSpecify: true,
+			initialAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "too/many/slashes",
+			},
+			expectedAnnotations: map[string]string{
+				// Invalid user input is deleted, mgmt is still applied
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "harvester-mgmt/vlan-100",
+			},
+		},
+		{
+			name:               "Management: Global config added when no user input exists",
+			mgmtNetwork:        "harvester-mgmt/vlan-100",
+			allowSpecify:       true,
+			initialAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "harvester-mgmt/vlan-100",
+			},
+		},
+		{
+			name:               "Management: Global config normalized if bare name",
+			mgmtNetwork:        "mgmt-vlan",
+			allowSpecify:       true,
+			initialAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "default/mgmt-vlan",
+			},
+		},
+		{
+			name:         "Management: Invalid global config stripped from annotations",
+			mgmtNetwork:  "invalid/global/net",
+			allowSpecify: true,
+			initialAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "old-val",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name:         "Permissions: User input stripped when allowSpecify is false",
+			mgmtNetwork:  "harvester-mgmt/vlan-100",
+			allowSpecify: false,
+			initialAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user-vlan",
+			},
+			expectedAnnotations: map[string]string{
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "harvester-mgmt/vlan-100",
+			},
+		},
+		{
+			name:         "Fallback: Both annotations removed if mgmt is empty and user input disabled",
 			mgmtNetwork:  "",
 			allowSpecify: false,
 			initialAnnotations: map[string]string{
-				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "user-vlan",
+				utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "old-mgmt",
 			},
 			expectedAnnotations: map[string]string{
-				// Result is empty -> Triggers Priority 3 (Fallback/Guess)
+				// Result is empty -> Harvester side will perform fallback discovery
 			},
 		},
 		{
-			name:         "Priority 2 Allowed: User specified and allowed globally",
+			name:         "Preservation: Non-related annotations are not touched",
+			mgmtNetwork:  "",
+			allowSpecify: false,
+			initialAnnotations: map[string]string{
+				"harvesterhci.io/other": "important-data",
+			},
+			expectedAnnotations: map[string]string{
+				"harvesterhci.io/other": "important-data",
+			},
+		},
+		{
+			name:         "Edge Case: Malformed parts (ns/) are stripped",
 			mgmtNetwork:  "",
 			allowSpecify: true,
 			initialAnnotations: map[string]string{
-				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
+				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "namespace/",
 			},
-			expectedAnnotations: map[string]string{
-				utils.AnnotationKeyGuestClusterNetworkNameOnLB: "user/vlan-200",
-			},
-		},
-		{
-			name:         "Legacy Case: No global config and no LB annotations",
-			mgmtNetwork:  "",    // No global flag set
-			allowSpecify: false, // Default/Legacy state
-			initialAnnotations: map[string]string{
-				"other-annotation": "stays-untouched",
-			},
-			expectedAnnotations: map[string]string{
-				"other-annotation": "stays-untouched",
-				// No new annotations added, none removed.
-			},
+			expectedAnnotations: map[string]string{},
 		},
 	}
 
+	originalManagementNetwork := cfg.ManagementNetwork
+	originalAllowSpecifyLoadBalancerNetwork := cfg.AllowSpecifyLoadBalancerNetwork
+
+	defer func() {
+		cfg.ManagementNetwork = originalManagementNetwork
+		cfg.AllowSpecifyLoadBalancerNetwork = originalAllowSpecifyLoadBalancerNetwork
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Set global config state
 			cfg.ManagementNetwork = tt.mgmtNetwork
 			cfg.AllowSpecifyLoadBalancerNetwork = tt.allowSpecify
 
 			lb := &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "test-ns",
+					Name:        "test-lb",
 					Annotations: tt.initialAnnotations,
 				},
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,10 +12,10 @@
 // no additional writes occur, making them safe for concurrent reads by plugins and controllers.
 package config
 
-var (
+type Config struct {
 	// defined by cloud-provider framework
 	ClusterName              string
-	CloudProviderControllers string // raw input is string slices, but converted by bootstrap
+	CloudProviderControllers string
 
 	// defined by Harvester, refer pkg/utils/consts.go for more information
 	ManagementNetwork               string
@@ -23,4 +23,10 @@ var (
 	AllowSpecifyLoadBalancerNetwork bool
 	DisableVMIController            bool
 	ShowFullHelpOnError             bool
-)
+}
+
+var _config = &Config{}
+
+func GetConfig() *Config {
+	return _config
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,25 +1,27 @@
 package config
 
-import "sync"
+import (
+	"fmt"
 
-var (
-	instance *Config
-	once     sync.Once
-
-	ManagementNetwork               string
-	AllowSpecifyLoadBalancerNetwork bool
-	ClusterName                     string
+	"github.com/harvester/harvester-cloud-provider/pkg/utils"
 )
 
-type Config struct {
-	ManagementNetwork               string
-	ClusterName                     string
-	AllowSpecifyLoadBalancerNetwork bool
-}
+var (
+	// defined by framework
+	ClusterName string
 
-func Get() *Config {
-	once.Do(func() {
-		instance = &Config{}
-	})
-	return instance
+	// defined by harvester
+	ManagementNetwork               string
+	AllowSpecifyLoadBalancerNetwork bool
+	DisableVMIController            bool
+	ShowFullHelpOnError             bool
+)
+
+func CurrentConfigString() string {
+	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
+		utils.FlagClusterName, ClusterName,
+		utils.FlagMgmtNetwork, ManagementNetwork,
+		utils.FlagAllowSpecifyLoadbalancerNetwork, AllowSpecifyLoadBalancerNetwork,
+		utils.FlagDisableVmiController, DisableVMIController,
+		utils.FlagShowFullHelpOnError, ShowFullHelpOnError)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,25 @@
+package config
+
+import "sync"
+
+var (
+	instance *Config
+	once     sync.Once
+
+	ManagementNetwork               string
+	AllowSpecifyLoadBalancerNetwork bool
+	ClusterName                     string
+)
+
+type Config struct {
+	ManagementNetwork               string
+	ClusterName                     string
+	AllowSpecifyLoadBalancerNetwork bool
+}
+
+func Get() *Config {
+	once.Do(func() {
+		instance = &Config{}
+	})
+	return instance
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,29 +1,26 @@
+// Package config stores global configuration data initialized during the cloud-provider boot sequence.
+//
+// ARCHITECTURAL DESIGN & TRADEOFFS:
+// The cloud-provider app lifecycle is managed by the underlying Kubernetes framework, not by our
+// direct code. Because the framework does not expose parsed flags directly to plugins after
+// initialization, storing them in this package is the current best tradeoff solution.
+//
+// CONCURRENCY & SAFETY:
+// These variables are populated once by the bootstrap process. Because the framework completes
+// flag parsing before starting any plugins or controller loops, there is no risk of race
+// conditions. After the boot phase, these variables are treated as effectively immutable;
+// no additional writes occur, making them safe for concurrent reads by plugins and controllers.
 package config
 
-import (
-	"fmt"
-
-	"github.com/harvester/harvester-cloud-provider/pkg/utils"
-)
-
 var (
-	// defined by framework
+	// defined by cloud-provider framework
 	ClusterName              string
 	CloudProviderControllers string // raw input is string slices, but converted by bootstrap
 
-	// defined by harvester
+	// defined by Harvester, refer pkg/utils/consts.go for more information
 	ManagementNetwork               string
+	NodeIPCIDR                      string
 	AllowSpecifyLoadBalancerNetwork bool
 	DisableVMIController            bool
 	ShowFullHelpOnError             bool
 )
-
-func CurrentConfigString() string {
-	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
-		utils.FlagClusterName, ClusterName,
-		utils.FlagCloudProviderControllers, CloudProviderControllers,
-		utils.FlagManagementNetwork, ManagementNetwork,
-		utils.FlagAllowSpecifyLoadbalancerNetwork, AllowSpecifyLoadBalancerNetwork,
-		utils.FlagDisableVmiController, DisableVMIController,
-		utils.FlagShowFullHelpOnError, ShowFullHelpOnError)
-}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,8 @@ import (
 
 var (
 	// defined by framework
-	ClusterName string
+	ClusterName              string
+	CloudProviderControllers string // raw input is string slices, but converted by bootstrap
 
 	// defined by harvester
 	ManagementNetwork               string
@@ -18,9 +19,10 @@ var (
 )
 
 func CurrentConfigString() string {
-	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
+	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
 		utils.FlagClusterName, ClusterName,
-		utils.FlagMgmtNetwork, ManagementNetwork,
+		utils.FlagCloudProviderControllers, CloudProviderControllers,
+		utils.FlagManagementNetwork, ManagementNetwork,
 		utils.FlagAllowSpecifyLoadbalancerNetwork, AllowSpecifyLoadBalancerNetwork,
 		utils.FlagDisableVmiController, DisableVMIController,
 		utils.FlagShowFullHelpOnError, ShowFullHelpOnError)

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -1,0 +1,220 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	cfg "github.com/harvester/harvester-cloud-provider/pkg/config" // Import data store
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func GetCurrentConfigString() string {
+	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
+		FlagClusterName, cfg.ClusterName,
+		FlagCloudProviderControllers, cfg.CloudProviderControllers,
+		FlagManagementNetwork, cfg.ManagementNetwork,
+		FlagNodeIPCIDR, cfg.NodeIPCIDR,
+		FlagAllowSpecifyLoadbalancerNetwork, cfg.AllowSpecifyLoadBalancerNetwork,
+		FlagDisableVmiController, cfg.DisableVMIController,
+		FlagShowFullHelpOnError, cfg.ShowFullHelpOnError)
+}
+
+// syncAndValidateHarvesterConfig bridges the gap between the K8s framework and Harvester needs.
+//
+// WHY:
+// The command flags are registered and processed by the underlying 'cloud-provider'
+// framework rather than our direct logic. The framework does not expose these
+// flags directly to the entire application; they are typically passed only to
+// specific plugins as needed. To log or verify these values globally before
+// the provider starts, this manual fetch is the most reliable method.
+//
+// CRITICALITY (Identity & Optional Network Precision):
+//  1. Cluster Name: Critical for identity. Defaults lead to resource collisions.
+//  2. Management Network (Optional): If provided, defines the specific Harvester
+//     network for node traffic. If omitted, discovery follows default logic.
+//  3. Node IP CIDR (Optional): If provided, acts as a deterministic filter for
+//     IP selection (vital for Dual-Stack, Multi-Home). If omitted, all valid IPs are candidates.
+//
+// VALIDATION POLICY (Strictly Optional, Strictly Validated):
+// To ensure environment stability, this function treats networking flags as
+// "Opt-in for Precision." They are not required to start the provider, but
+// if present, they must be correct:
+//
+// The provider will return an error and terminate (Fail-Fast) only if:
+//   - A provided --management-network name is malformed.
+//   - A provided --node-ip-cidr contains syntax errors, restricted ranges
+//     (loopback/link-local), or non-unicast addresses.
+//
+// This prevents the provider from falling back to "guessing" when the user
+// has explicitly expressed a configuration intent.
+//
+// DEPLOYMENT NOTE:
+//
+//   - Direct Deployment: Ensure container args include "--cluster-name=a-unique-name".
+//
+//   - Helm Chart Deployment: Ensure the following configuration is set (which
+//     is eventually converted into the deployment container args):
+//
+//     rkeConfig:
+//     chartValues:
+//     harvester-cloud-provider:
+//     global:
+//     cattle:
+//     clusterName: a-unique-name
+//
+// HOW:
+// We fetch values here via RunE to ensure global synchronization before the
+// framework branches into multi-threaded controller execution.
+//
+// TROUBLESHOOTING:
+// We log these values clearly at boot time to allow for immediate verification
+// of the runtime configuration in production logs.
+func SyncAndValidateHarvesterConfig(cmd *cobra.Command) error {
+	flags := cmd.Flags()
+
+	// 1. Helper to retrieve flags safely without panicking.
+	// Errors here indicate a code-level mismatch (flag not registered).
+	getStr := func(name string) (string, error) {
+		val, err := flags.GetString(name)
+		if err != nil {
+			return "", fmt.Errorf("internal error: flag %q not registered: %w", name, err)
+		}
+		return val, nil
+	}
+	getBool := func(name string) (bool, error) {
+		val, err := flags.GetBool(name)
+		if err != nil {
+			return false, fmt.Errorf("internal error: flag %q not registered: %w", name, err)
+		}
+		return val, nil
+	}
+	getStrSlice := func(name string) ([]string, error) {
+		val, err := flags.GetStringSlice(name)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: flag %q not registered as stringSlice: %w", name, err)
+		}
+		return val, nil
+	}
+
+	// 2. Sync values and check for registration errors
+	var err error
+	if cfg.ClusterName, err = getStr(FlagClusterName); err != nil {
+		return err
+	}
+	if cfg.ManagementNetwork, err = getStr(FlagManagementNetwork); err != nil {
+		return err
+	}
+	if cfg.NodeIPCIDR, err = getStr(FlagNodeIPCIDR); err != nil {
+		return err
+	}
+	if cfg.DisableVMIController, err = getBool(FlagDisableVmiController); err != nil {
+		return err
+	}
+	if cfg.AllowSpecifyLoadBalancerNetwork, err = getBool(FlagAllowSpecifyLoadbalancerNetwork); err != nil {
+		return err
+	}
+	if cfg.ShowFullHelpOnError, err = getBool(FlagShowFullHelpOnError); err != nil {
+		return err
+	}
+
+	controllerSlice, err := getStrSlice(FlagCloudProviderControllers)
+	if err != nil {
+		return err
+	}
+	cfg.CloudProviderControllers = strings.Join(controllerSlice, ",")
+
+	// 3. Logic Validation: ClusterName (Warning only, as per existing logic)
+	if cfg.ClusterName == "" || cfg.ClusterName == DefaultGuestClusterName {
+		logrus.Warnf("%s WARNING: the flag --%s is using an empty or default value (current value: %q). "+
+			"A unique cluster name is required for remote systems to identify this cluster.",
+			HarvesterCloudProvider, FlagClusterName, cfg.ClusterName)
+	}
+
+	// 4. Strict Validation: Management Network
+	// If the user provided a value, it MUST be valid. We no longer drop and continue.
+	if cfg.ManagementNetwork != "" {
+		normalized, err := NormalizeNetworkName(NetworkTypeManagement, cfg.ManagementNetwork)
+		if err != nil {
+			return fmt.Errorf("invalid configuration for --%s: %w", FlagManagementNetwork, err)
+		}
+		cfg.ManagementNetwork = normalized
+	}
+
+	// 5. Strict Validation: Node IP CIDR
+	// Fail early if the CIDR format or range is invalid.
+	if cfg.NodeIPCIDR != "" {
+		if err := ValidateCIDRFilter(cfg.NodeIPCIDR); err != nil {
+			return fmt.Errorf("invalid configuration for --%s: %w", FlagNodeIPCIDR, err)
+		}
+	}
+
+	logrus.Infof("%s effective configurations: %s", HarvesterCloudProvider, GetCurrentConfigString())
+	return nil
+}
+
+// CheckFlagShowFullHelpOnError determines if the user wants the standard, concise
+// or the full cloud-provider framework help dump.
+//
+// DEBUGGING TIP: If you need to see the full list of supported flags,
+// manually edit the deployment/statefulset and add the following argument:
+//
+//	args:
+//	  - --show-full-help-on-error=true
+//
+// This is intentionally not exposed in the standard Helm Chart to keep
+// the user interface clean and prevent accidentally flooding production logs.
+func CheckFlagShowFullHelpOnError(cmd *cobra.Command) {
+	showFullHelp := false
+	for _, arg := range os.Args {
+		// We check os.Args directly because this happens before cmd.Execute()
+		if arg == "--"+FlagShowFullHelpOnError+"=true" || arg == "--"+FlagShowFullHelpOnError {
+			showFullHelp = true
+			break
+		}
+	}
+
+	if !showFullHelp {
+		// Silence the massive help wall and internal Cobra error printing
+		// so we can provide our own high-signal troubleshooting logs.
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+	}
+	cfg.ShowFullHelpOnError = showFullHelp
+}
+
+// HandleStartupError provides a clean, user-friendly exit when the application fails to start.
+// Since the harvester-cloud-provider Helm chart allows users to inject custom flags via '.Values.extraArgs',
+// it is essential to check if the failure is due to an unknown flag. This ensures users
+// get clear feedback regarding typos in their Helm configuration rather than a generic crash.
+func HandleStartupError(err error) {
+	errStr := err.Error()
+
+	// Visual boundary to separate the error from standard container logs
+	logrus.Errorf("=============================================================================================")
+	logrus.Errorf("FATAL: %s failed to start", HarvesterCloudProvider)
+
+	// Detect flag-related errors (typos, unsupported flags, etc.)
+	isFlagError := strings.Contains(errStr, "unknown flag") ||
+		strings.Contains(errStr, "flag provided but not defined") ||
+		strings.Contains(errStr, "bad flag syntax")
+
+	logrus.Errorf("Error detail: %v", err)
+
+	if isFlagError {
+		logrus.Errorf("Potential cause: invalid flag(s) detected.")
+		logrus.Errorf("Helm check: verify the list in '.Values.extraArgs' within your values.yaml.")
+		logrus.Errorf("Action: ensure flags use the '--name=value' format and are supported by this version.")
+
+		if !cfg.ShowFullHelpOnError {
+			logrus.Infof("Hint: set '--show-full-help-on-error=true' to see all valid flags in the logs.")
+		}
+	}
+
+	// other logic-based errors (RBAC, Network, API, etc.)
+	logrus.Errorf("=============================================================================================")
+
+	// Always exit with a non-zero code to trigger a Pod restart/error state
+	os.Exit(1)
+}

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -5,12 +5,16 @@ import (
 	"os"
 	"strings"
 
-	cfg "github.com/harvester/harvester-cloud-provider/pkg/config" // Import data store
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/harvester/harvester-cloud-provider/pkg/config" // Import data store
 )
 
-func GetCurrentConfigString() string {
+func GetCurrentConfigString(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
 	return fmt.Sprintf("--%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v --%s=%v",
 		FlagClusterName, cfg.ClusterName,
 		FlagCloudProviderControllers, cfg.CloudProviderControllers,
@@ -71,7 +75,7 @@ func GetCurrentConfigString() string {
 // TROUBLESHOOTING:
 // We log these values clearly at boot time to allow for immediate verification
 // of the runtime configuration in production logs.
-func SyncAndValidateHarvesterConfig(cmd *cobra.Command) error {
+func SyncAndValidateHarvesterConfig(cmd *cobra.Command, cfg *config.Config) error {
 	flags := cmd.Flags()
 
 	// 1. Helper to retrieve flags safely without panicking.
@@ -150,7 +154,7 @@ func SyncAndValidateHarvesterConfig(cmd *cobra.Command) error {
 		}
 	}
 
-	logrus.Infof("%s effective configurations: %s", HarvesterCloudProvider, GetCurrentConfigString())
+	logrus.Infof("%s effective configurations: %s", HarvesterCloudProvider, GetCurrentConfigString(cfg))
 	return nil
 }
 
@@ -165,7 +169,7 @@ func SyncAndValidateHarvesterConfig(cmd *cobra.Command) error {
 //
 // This is intentionally not exposed in the standard Helm Chart to keep
 // the user interface clean and prevent accidentally flooding production logs.
-func CheckFlagShowFullHelpOnError(cmd *cobra.Command) {
+func CheckFlagShowFullHelpOnError(cmd *cobra.Command, cfg *config.Config) {
 	showFullHelp := false
 	for _, arg := range os.Args {
 		// We check os.Args directly because this happens before cmd.Execute()
@@ -188,7 +192,7 @@ func CheckFlagShowFullHelpOnError(cmd *cobra.Command) {
 // Since the harvester-cloud-provider Helm chart allows users to inject custom flags via '.Values.extraArgs',
 // it is essential to check if the failure is due to an unknown flag. This ensures users
 // get clear feedback regarding typos in their Helm configuration rather than a generic crash.
-func HandleStartupError(err error) {
+func HandleStartupError(cfg *config.Config, err error) {
 	errStr := err.Error()
 
 	// Visual boundary to separate the error from standard container logs

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -1,0 +1,206 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"reflect"
+	"testing"
+
+	"github.com/harvester/harvester-cloud-provider/pkg/config"
+)
+
+func Test_SyncAndValidateHarvesterConfig(t *testing.T) {
+	// 1. Save original state and setup restore helper
+	originalConfig := *config.GetConfig()
+	restoreTo := func(c config.Config) {
+		*config.GetConfig() = c
+	}
+	defer restoreTo(originalConfig)
+
+	tests := []struct {
+		name       string
+		inputFlags map[string]interface{}
+		sliceFlags map[string][]string
+		expected   config.Config
+		wantErr    bool
+	}{
+		// --- HAPPY CASES ---
+		{
+			name: "Full configuration",
+			inputFlags: map[string]interface{}{
+				FlagClusterName:                     "prod-cluster",
+				FlagManagementNetwork:               "harvester-public/vlan100",
+				FlagNodeIPCIDR:                      "192.168.0.0/24",
+				FlagDisableVmiController:            true,
+				FlagAllowSpecifyLoadbalancerNetwork: true,
+				FlagShowFullHelpOnError:             true,
+			},
+			sliceFlags: map[string][]string{
+				FlagCloudProviderControllers: {"node", "loadbalancer"},
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName:                     "prod-cluster",
+				CloudProviderControllers:        "node,loadbalancer",
+				ManagementNetwork:               "harvester-public/vlan100", // Assuming normalization doesn't change this string
+				NodeIPCIDR:                      "192.168.0.0/24",
+				DisableVMIController:            true,
+				AllowSpecifyLoadBalancerNetwork: true,
+				ShowFullHelpOnError:             true,
+			},
+		},
+		{
+			name: "IPv6 CIDR Support",
+			inputFlags: map[string]interface{}{
+				FlagClusterName: "ipv6-cluster",
+				FlagNodeIPCIDR:  "2001:db8::/32",
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName: "ipv6-cluster",
+				NodeIPCIDR:  "2001:db8::/32",
+			},
+		},
+		{
+			name: "Dual-stack CIDR ",
+			inputFlags: map[string]interface{}{
+				FlagClusterName: "dual-stack-cluster",
+				FlagNodeIPCIDR:  "192.168.0.0/24,2001:db8::/32",
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName: "dual-stack-cluster",
+				NodeIPCIDR:  "192.168.0.0/24,2001:db8::/32",
+			},
+		},
+		{
+			name: "Management Network default namespace auto-append",
+			inputFlags: map[string]interface{}{
+				FlagClusterName:       "net-cluster",
+				FlagManagementNetwork: "vlan100", // No namespace provided
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName:       "net-cluster",
+				ManagementNetwork: "default/vlan100",
+			},
+		},
+		{
+			name: "Default values",
+			inputFlags: map[string]interface{}{
+				FlagClusterName: "minimal-cluster",
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName: "minimal-cluster",
+				// Other fields remain zero-valued
+			},
+		},
+		{
+			name: "Explict cluster-name flag with empty string",
+			inputFlags: map[string]interface{}{
+				FlagClusterName: "",
+			},
+			wantErr: false,
+			expected: config.Config{
+				ClusterName: "",
+				// Other fields remain zero-valued
+			},
+		},
+		// --- ERROR CASES ---
+		{
+			name: "Error: Invalid CIDR",
+			inputFlags: map[string]interface{}{
+				FlagNodeIPCIDR: "999.999.999.999/invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error: Invalid CIDR, IPv4 local host",
+			inputFlags: map[string]interface{}{
+				FlagNodeIPCIDR: "127.0.0.0/8",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error: Invalid CIDR, IPv6 link local",
+			inputFlags: map[string]interface{}{
+				FlagNodeIPCIDR: "fe80::/10",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error: Management Network with too many segments",
+			inputFlags: map[string]interface{}{
+				FlagManagementNetwork: "namespace/network/invalid-segment",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error: IPv4 CIDR with trailing garbage",
+			inputFlags: map[string]interface{}{
+				FlagNodeIPCIDR: "192.168.1.0/24-invalid-string",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error: IPv6 CIDR with invalid range",
+			inputFlags: map[string]interface{}{
+				FlagNodeIPCIDR: "2001:db8::/129", // IPv6 max is 128
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 2. Wipe global config for isolation
+			restoreTo(config.Config{})
+			targetCfg := config.GetConfig()
+
+			// 3. Setup Command and register flags
+			cmd := &cobra.Command{}
+			f := cmd.Flags()
+			f.String(FlagClusterName, "", "")
+			f.String(FlagManagementNetwork, "", "")
+			f.String(FlagNodeIPCIDR, "", "")
+			f.Bool(FlagDisableVmiController, false, "")
+			f.Bool(FlagAllowSpecifyLoadbalancerNetwork, false, "")
+			f.Bool(FlagShowFullHelpOnError, false, "")
+			f.StringSlice(FlagCloudProviderControllers, []string{}, "")
+
+			// 4. Inject values
+			for k, v := range tt.inputFlags {
+				_ = f.Set(k, fmt.Sprintf("%v", v))
+			}
+			for k, v := range tt.sliceFlags {
+				for _, val := range v {
+					_ = f.Set(k, val)
+				}
+			}
+
+			// 5. Execute
+			err := SyncAndValidateHarvesterConfig(cmd, targetCfg)
+
+			// 6. Assertions
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("[%s] expected error but got nil", tt.name)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("[%s] unexpected error: %v", tt.name, err)
+				return
+			}
+
+			// 7. Deep Comparison
+			actual := *targetCfg
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("[%s] content mismatch!\nExpected: %+v\nActual:   %+v",
+					tt.name, tt.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -42,7 +42,7 @@ func Test_SyncAndValidateHarvesterConfig(t *testing.T) {
 			expected: config.Config{
 				ClusterName:                     "prod-cluster",
 				CloudProviderControllers:        "node,loadbalancer",
-				ManagementNetwork:               "harvester-public/vlan100", // Assuming normalization doesn't change this string
+				ManagementNetwork:               "harvester-public/vlan100",
 				NodeIPCIDR:                      "192.168.0.0/24",
 				DisableVMIController:            true,
 				AllowSpecifyLoadBalancerNetwork: true,
@@ -97,7 +97,7 @@ func Test_SyncAndValidateHarvesterConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "Explict cluster-name flag with empty string",
+			name: "Explicit cluster-name flag with empty string",
 			inputFlags: map[string]interface{}{
 				FlagClusterName: "",
 			},
@@ -105,6 +105,15 @@ func Test_SyncAndValidateHarvesterConfig(t *testing.T) {
 			expected: config.Config{
 				ClusterName: "",
 				// Other fields remain zero-valued
+			},
+		},
+		{
+			name:       "No input flag",
+			inputFlags: map[string]interface{}{},
+			wantErr:    false,
+			expected:   config.Config{
+				// note: the cloud-provider framework injects "kubernetes" as cluster-name
+				// but on test code this case is not covered
 			},
 		},
 		// --- ERROR CASES ---

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -5,12 +5,12 @@ const (
 
 	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
 
-	// when guest cluster has multi network, it can explicitly say which one is the management network, instead of guess or hardcode
+	// when a guest cluster has multiple networks, it can explicitly say which one is the management network, instead of guessing or hardcoding
 	LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
 
 	// if guest cluster sets a target network, then respect it
 	LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
 
-	// cloud-prvoider framework injects `kubernetes` as cluster name, when it is not set by runtime env `--cluster-name`
+	// cloud-provider framework injects `kubernetes` as cluster name when it is not set by runtime env `--cluster-name`
 	DefaultGuestClusterName = "kubernetes"
 )

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,0 +1,16 @@
+package utils
+
+const (
+	HarvesterCloudProvider = "cloudprovider.harvesterhci.io"
+
+	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
+
+	// when guest cluster has multi network, it can explicitly say which one is the management network, instead of guess or hardcode
+	LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
+
+	// if guest cluster sets a target network, then respect it
+	LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
+
+	// cloud-prvoider framework injects `kubernetes` as cluster name, when it is not set by runtime env `--cluster-name`
+	DefaultGuestClusterName = "kubernetes"
+)

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -5,12 +5,42 @@ const (
 
 	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
 
+	// LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
+
 	// when a guest cluster has multiple networks, it can explicitly say which one is the management network, instead of guessing or hardcoding
-	LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
+	// value format: `default/vlan100`
+	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
+
+	// LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
 
 	// if guest cluster sets a target network, then respect it
-	LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
+	// // value format: `project200/vlan200`
+	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
 
 	// cloud-provider framework injects `kubernetes` as cluster name when it is not set by runtime env `--cluster-name`
 	DefaultGuestClusterName = "kubernetes"
+
+	// flags defined by framework
+	FlagClusterName = "cluster-name"
+
+	// flags defined by harvester
+	FlagDisableVmiController = "disable-vmi-controller"
+
+	FlagMgmtNetwork = "management-network"
+
+	FlagAllowSpecifyLoadbalancerNetwork = "allow-specify-loadbalancer-network"
+
+	// FlagShowFullHelpOnError toggles the display of the full framework help menu on startup failure.
+	// Since users utilize '.Values.extraArgs' to tune cloud-provider framework features—such as
+	// utilizing '--controllers' to enable or disable specific sub-controllers—we disable the
+	// verbose help dump by default. This ensures configuration errors remain the focus of the logs.
+	//
+	// Example of a framework-level error handled by this logic:
+	//   Command: ... --controllers=cloud-node-controller,node-route-controller,unknown
+	//   Output:
+	//     ERRO: =============================================================================================
+	//     ERRO: FATAL: cloudprovider.harvesterhci.io failed to start
+	//     ERRO: Error detail: "unknown" is not in the list of known controllers
+	//     ERRO: =============================================================================================
+	FlagShowFullHelpOnError = "show-full-help-on-error"
 )

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -7,26 +7,33 @@ const (
 
 	// LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
 
+	NetworkTypeManagement = "managementNetwork"
+
+	NetworkTypeLB = "lbNetwork"
+
 	// when a guest cluster has multiple networks, it can explicitly say which one is the management network, instead of guessing or hardcoding
 	// value format: `default/vlan100`
-	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
+	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
 
 	// LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
 
 	// if guest cluster sets a target network, then respect it
 	// // value format: `project200/vlan200`
-	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
+	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + NetworkTypeLB
 
 	// cloud-provider framework injects `kubernetes` as cluster name when it is not set by runtime env `--cluster-name`
 	DefaultGuestClusterName = "kubernetes"
 
+	DefaultNamespace = "default"
+
 	// flags defined by framework
-	FlagClusterName = "cluster-name"
+	FlagClusterName              = "cluster-name"
+	FlagCloudProviderControllers = "controllers"
 
 	// flags defined by harvester
 	FlagDisableVmiController = "disable-vmi-controller"
 
-	FlagMgmtNetwork = "management-network"
+	FlagManagementNetwork = "management-network"
 
 	FlagAllowSpecifyLoadbalancerNetwork = "allow-specify-loadbalancer-network"
 

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -28,8 +28,7 @@ const (
 	// replace `serviceNameKey      = prefix + "serviceName"`
 	LBServiceNameKey = HarvesterCloudProviderPrefix + "serviceName"
 
-	// LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
-
+	// new definitions
 	NetworkTypeManagement = "managementNetwork"
 
 	NetworkTypeLB = "lbNetwork"
@@ -38,13 +37,13 @@ const (
 	// value format: `default/vlan100`
 	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
 
-	// LabelKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + "lbNetwork"
-
 	// if guest cluster sets a target network, then respect it
-	// // value format: `project200/vlan200`
+	// value format: `project200/vlan200`
 	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + NetworkTypeLB
 
-	// cloud-provider framework injects `kubernetes` as cluster name when it is not set by runtime env `--cluster-name`
+	// cloud-provider framework injects `kubernetes` as cluster-name when runtime env `--cluster-name` is not set
+	// if `--cluster-name=abc` then `cluster-name` is `abc`
+	// if `--cluster-name=` then `cluster-name` is `` (empty)
 	DefaultGuestClusterName = "kubernetes"
 
 	DefaultNamespace = "default"
@@ -53,7 +52,7 @@ const (
 	FlagClusterName              = "cluster-name"
 	FlagCloudProviderControllers = "controllers"
 
-	// flags defined by harvester
+	// flags defined by Harvester
 	FlagDisableVmiController = "disable-vmi-controller"
 
 	FlagManagementNetwork = "management-network"
@@ -73,4 +72,22 @@ const (
 	//     ERRO: Error detail: "unknown" is not in the list of known controllers
 	//     ERRO: =============================================================================================
 	FlagShowFullHelpOnError = "show-full-help-on-error"
+
+	// FlagNodeIPCIDR is the global filter for allowed node IP ranges.
+	// Supports dual-stack (e.g., "192.168.122.0/24,2001:db8::/64").
+	// When a node has multi-nics or multi-ips, we use this to precisely select
+	// the correct node-ip and avoid deterministic "guessing" failures.
+	FlagNodeIPCIDR = "node-ip-cidr"
+
+	// node-ip related
+
+	// Note:
+	// AnnotationAlphaProvidedIPAddr ("alpha.kubernetes.io/provided-node-ip")
+	// from "k8s.io/cloud-provider/api/well_known_annotations.go".
+	// is always respected first as a legacy override for backward compatibility.
+
+	// KeyNodeIPCIDR matches the user-defined mgmtCIDR configuration.
+	// This is the primary Harvester-specific way to filter node IPs.
+	// It supports dual-stack via comma-separated CIDRs.
+	KeyNodeIPCIDR = HarvesterCloudProviderPrefix + "node-ip-cidr"
 )

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -5,6 +5,29 @@ const (
 
 	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
 
+	// original defined on pkg/cloud-controller-manager/annotation.go, moved to here
+	KeyIPAM           = HarvesterCloudProviderPrefix + "ipam"
+	KeyNetwork        = HarvesterCloudProviderPrefix + "network"
+	KeyProject        = HarvesterCloudProviderPrefix + "project"
+	KeyNamespace      = HarvesterCloudProviderPrefix + "namespace"
+	KeyPrimaryService = HarvesterCloudProviderPrefix + "primary-service"
+
+	KeyKubevipLoadBalancerIP = "kube-vip.io/loadbalancerIPs"
+
+	KeyAdditionalInternalIPs = HarvesterCloudProviderPrefix + "additional-internal-ips"
+
+	// original defined&unexported on pkg/cloud-controller-manager/loadbalancer.go
+	// moved to here with adding LB prefix
+
+	// replace `clusterNameKey      = prefix + "cluster"`
+	LBClusterNameKey = HarvesterCloudProviderPrefix + "cluster"
+
+	// replace `serviceNamespaceKey = prefix + "serviceNamespace"`
+	LBServiceNamespaceKey = HarvesterCloudProviderPrefix + "serviceNamespace"
+
+	// replace `serviceNameKey      = prefix + "serviceName"`
+	LBServiceNameKey = HarvesterCloudProviderPrefix + "serviceName"
+
 	// LabelKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + "managementNetwork"
 
 	NetworkTypeManagement = "managementNetwork"

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// BootstrapLogrus level-peeks at os.Args before formal flag parsing to set the Logrus level.
+// This solves the bootstrap paradox where we need to log initialization errors or
+// raw arguments before the cloud-provider framework's flag parsing is complete.
+// The log-level flag supported by cloud-provider framework
+// -v, --v Level
+//
+//	number for the log level verbosity
+//
+// It maps the klog '-v' or '--v' verbosity levels to Logrus levels:
+//
+//	v >= 5: TraceLevel (Logs raw os.Args)
+//	v >= 3: DebugLevel
+//	v < 3:  InfoLevel (Default)
+func BootstrapLogrus() {
+	level := logrus.InfoLevel
+
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "-v=") || strings.HasPrefix(arg, "--v=") {
+			// Cut splits at the first occurrence of "="
+			_, value, found := strings.Cut(arg, "=")
+			if found {
+				level = MapK8sLevelToLogrus(value)
+			}
+		} else if (arg == "-v" || arg == "--v") && i+1 < len(os.Args) {
+			level = MapK8sLevelToLogrus(os.Args[i+1])
+		}
+	}
+
+	logrus.SetLevel(level)
+
+	if level >= logrus.TraceLevel {
+		logrus.Warn("BOOTSTRAP: High verbosity detected. Logging raw arguments.")
+		logrus.Tracef("Raw os.Args: %v", os.Args)
+	}
+}
+
+// MapK8sLevelToLogrus converts a klog verbosity string to a logrus Level.
+func MapK8sLevelToLogrus(vString string) logrus.Level {
+	v, err := strconv.Atoi(vString)
+	if err != nil {
+		return logrus.InfoLevel
+	}
+
+	switch {
+	case v >= 5:
+		return logrus.TraceLevel
+	case v >= 3:
+		return logrus.DebugLevel
+	default:
+		return logrus.InfoLevel
+	}
+}

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -45,7 +45,8 @@ func ValidateCIDRFilter(cidrFilter string) error {
 		}
 
 		// 1. Strict Syntax Check
-		ip, ipNet, err := net.ParseCIDR(cidr)
+		var ip net.IP
+		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			ip = net.ParseIP(cidr)
 			if ip == nil {
@@ -65,7 +66,7 @@ func ValidateCIDRFilter(cidrFilter string) error {
 
 		// 3. Multicast/Global Unicast Check
 		// Nodes must have Unicast addresses. 224.0.0.0/4 (Multicast) or 255.255.255.255 are invalid.
-		if ip.IsMulticast() || ip.IsGlobalUnicast() == false {
+		if ip.IsMulticast() || !ip.IsGlobalUnicast() {
 			// Note: IsGlobalUnicast() returns true for private ranges like 10.0.0.0/8
 			// but false for the limited broadcast 255.255.255.255.
 			return fmt.Errorf("invalid filter %q: must be a valid unicast address range", cidr)

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NormalizeNetworkName ensures a network string is in the "namespace/name" format.
+// It returns the normalized string or an error if the format is fundamentally broken.
+func NormalizeNetworkName(networkType, networkName string) (string, error) {
+	if networkName == "" {
+		return "", fmt.Errorf("network type %s: network name is empty", networkType)
+	}
+
+	parts := strings.Split(networkName, "/")
+	switch len(parts) {
+	case 1:
+		// Bare name -> default/name
+		return fmt.Sprintf("%s/%s", DefaultNamespace, networkName), nil
+	case 2:
+		// Ensure neither part is empty (e.g., "ns/" or "/name")
+		if parts[0] == "" || parts[1] == "" {
+			return "", fmt.Errorf("invalid network type %s format %q, expected 'namespace/name'", networkType, networkName)
+		}
+		return networkName, nil
+	default:
+		// Too many slashes
+		return "", fmt.Errorf("network type %s name %q has too many slashes", networkType, networkName)
+	}
+}

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -27,4 +28,81 @@ func NormalizeNetworkName(networkType, networkName string) (string, error) {
 		// Too many slashes
 		return "", fmt.Errorf("network type %s name %q has too many slashes", networkType, networkName)
 	}
+}
+
+// ValidateCIDRFilter checks if the string is a valid comma-separated list of CIDRs or IPs.
+// This is called during bootstrap to "Fail Early".
+// ValidateCIDRFilter ensures the input is syntactically correct AND logically sound.
+func ValidateCIDRFilter(cidrFilter string) error {
+	if cidrFilter == "" {
+		return nil
+	}
+
+	for _, part := range strings.Split(cidrFilter, ",") {
+		cidr := strings.TrimSpace(part)
+		if cidr == "" {
+			continue
+		}
+
+		// 1. Strict Syntax Check
+		ip, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			ip = net.ParseIP(cidr)
+			if ip == nil {
+				return fmt.Errorf("invalid CIDR or IP format: %q (expected x.x.x.x/bb or x.x.x.x)", cidr)
+			}
+		} else {
+			ip = ipNet.IP
+		}
+
+		// 2. Logical Safety Check (The "No-Go" Zone)
+		if ip.IsLoopback() {
+			return fmt.Errorf("invalid filter %q: loopback addresses are not allowed", cidr)
+		}
+		if ip.IsLinkLocalUnicast() {
+			return fmt.Errorf("invalid filter %q: link-local addresses (APIPA) are not allowed", cidr)
+		}
+
+		// 3. Multicast/Global Unicast Check
+		// Nodes must have Unicast addresses. 224.0.0.0/4 (Multicast) or 255.255.255.255 are invalid.
+		if ip.IsMulticast() || ip.IsGlobalUnicast() == false {
+			// Note: IsGlobalUnicast() returns true for private ranges like 10.0.0.0/8
+			// but false for the limited broadcast 255.255.255.255.
+			return fmt.Errorf("invalid filter %q: must be a valid unicast address range", cidr)
+		}
+	}
+	return nil
+}
+
+// VerifyNodeIPCIDR is called at runtime by the controller.
+// Since ValidateCIDRFilter ran at boot, we know cidrFilter is syntactically correct.
+func VerifyNodeIPCIDR(ipStr string, cidrFilter string) bool {
+	target := net.ParseIP(ipStr)
+	if target == nil {
+		return false
+	}
+
+	// Always block loopback/link-local regardless of filter
+	if target.IsLoopback() || target.IsLinkLocalUnicast() {
+		return false
+	}
+
+	if cidrFilter == "" {
+		return true
+	}
+
+	// Logical match (We can skip error checking here because bootstrap already validated it)
+	for _, part := range strings.Split(cidrFilter, ",") {
+		cidr := strings.TrimSpace(part)
+		if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
+			if ipNet.Contains(target) {
+				return true
+			}
+		} else if filterIP := net.ParseIP(cidr); filterIP != nil {
+			if filterIP.Equal(target) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/utils/network_test.go
+++ b/pkg/utils/network_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -83,6 +84,104 @@ func Test_normalizeNetworkName(t *testing.T) {
 			// Check if the resulting string matches
 			if got != tt.want {
 				t.Errorf("NormalizeNetworkName() got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCIDRFilter_Comprehensive(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		// --- GOOD CASES ---
+		{
+			name:    "IPv4 Only Mode",
+			input:   "192.168.10.0/24",
+			wantErr: false,
+		},
+		{
+			name:    "IPv6 Only Mode",
+			input:   "2001:db8::/64",
+			wantErr: false,
+		},
+		{
+			name:    "Dual Stack Mode (Standard)",
+			input:   "10.0.0.0/8, fd00::/64",
+			wantErr: false,
+		},
+		{
+			name:    "Dual Stack with Literal IPs",
+			input:   "172.16.1.5, 2001:db8::fe21",
+			wantErr: false,
+		},
+		{
+			name:    "Complex Multi-Range (Legacy + Management + IPv6)",
+			input:   "10.0.0.0/24, 192.168.1.0/24, 2001:db8:a::/48",
+			wantErr: false,
+		},
+		{
+			name:    "Empty Input (Allowed, means no filtering)",
+			input:   "",
+			wantErr: false,
+		},
+
+		// --- ERROR CASES ---
+		{
+			name:    "Malformed: Impossible IPv4 Mask",
+			input:   "192.168.122.0/36",
+			wantErr: true,
+			errMsg:  "invalid CIDR",
+		},
+		{
+			name:    "Malformed: Missing Octet",
+			input:   "192.168.1/24",
+			wantErr: true,
+			errMsg:  "invalid CIDR",
+		},
+		{
+			name:    "Logical: Loopback Block",
+			input:   "127.0.0.1",
+			wantErr: true,
+			errMsg:  "loopback",
+		},
+		{
+			name:    "Logical: Link-Local Block",
+			input:   "fe80::/10",
+			wantErr: true,
+			errMsg:  "link-local",
+		},
+		{
+			name:    "Logical: Multicast Block",
+			input:   "224.0.0.1",
+			wantErr: true,
+			errMsg:  "unicast",
+		},
+		{
+			name:    "Poisoned List: One bad CIDR in Dual Stack",
+			input:   "10.0.0.0/24, 2001:db8::/129", // IPv6 mask too large
+			wantErr: true,
+			errMsg:  "invalid CIDR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCIDRFilter(tt.input)
+
+			// 1. Check if we got an error when we expected one
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCIDRFilter(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+
+			// 2. If an error occurred, verify the message content
+			if tt.wantErr && err != nil {
+				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.errMsg)) {
+					t.Errorf("ValidateCIDRFilter(%q) error %q did not contain keyword %q", tt.input, err.Error(), tt.errMsg)
+				}
 			}
 		})
 	}

--- a/pkg/utils/network_test.go
+++ b/pkg/utils/network_test.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"testing"
+)
+
+func Test_normalizeNetworkName(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkType string
+		input       string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "Empty input is an error",
+			networkType: NetworkTypeManagement,
+			input:       "",
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "Bare name is normalized to default namespace",
+			networkType: NetworkTypeManagement,
+			input:       "vlan-100",
+			want:        "default/vlan-100",
+			wantErr:     false,
+		},
+		{
+			name:        "Already namespaced name is preserved",
+			networkType: NetworkTypeLB,
+			input:       "harvester-public/vlan-200",
+			want:        "harvester-public/vlan-200",
+			wantErr:     false,
+		},
+		{
+			name:        "Normalized name in default namespace is preserved",
+			networkType: NetworkTypeLB,
+			input:       "default/vlan-100",
+			want:        "default/vlan-100",
+			wantErr:     false,
+		},
+		{
+			name:        "Error: Too many slashes",
+			networkType: NetworkTypeLB,
+			input:       "too/many/slashes",
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "Error: Missing name part",
+			networkType: NetworkTypeLB,
+			input:       "namespace/",
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "Error: Missing namespace part",
+			networkType: NetworkTypeLB,
+			input:       "/name",
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "Error: Only a slash",
+			networkType: NetworkTypeLB,
+			input:       "/",
+			want:        "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeNetworkName(tt.networkType, tt.input)
+
+			// Check if we got an error when we expected one
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeNetworkName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Check if the resulting string matches
+			if got != tt.want {
+				t.Errorf("NormalizeNetworkName() got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

To enhance the cloud-provider-harvester to have following features:

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Check `cluster-name` to have an early warning message upon empty or default value, this is the most possible failure of LB not syncing.

```
--cluster-name=kubernetes or empty
```
- Warn on each LB allocation, if `--cluster-name` is like above

- Add new flag `management-network` to specify the management network, to support multi networks

```
--management-network= (showing if it was dropped due to invalid input)
```

- Add new flag `allow-specify-loadbalancer-network` to toggle: if user could annotate the LB to specify the target network

```
--allow-specify-loadbalancer-network=true
```

- Log the `controllers` flag, which is most expected to be customizable (e.g. turn off the LB controller), for better troubleshooting

```
--controllers=cloud-node-controller,cloud-node-lifecycle-controller,...
```

- Patch the LB per above `management-network` and `allow-specify-loadbalancer-network`:

```
if `management-network` is set a valid value, patch it to lb annotation, if empty, remove it

if `allow-specify-loadbalancer-network`, keep user annotation ``, otherwise, remove it

all invalid format of network like `ns/name/name` or `ns/` or `/name` are dropped.
```


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10381
https://github.com/harvester/harvester/issues/9807 (disable LB on cloud-provider-harvester)

e.g.  https://github.com/harvester/harvester/issues/10123, the `cluster-name` is missing

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

cross-check:

https://github.com/harvester/cloud-provider-harvester/pull/50