### PR TITLE
Limit the first matched IP as internal in node-ip-cidr mode

### DIFF
--- a/pkg/cloud-controller-manager/instance.go
+++ b/pkg/cloud-controller-manager/instance.go
@@ -141,6 +141,9 @@ func getNodeAddresses(node *v1.Node, vmi *kubevirtv1.VirtualMachineInstance, cfg
 	getHostNameAddress := func() v1.NodeAddress {
 		return v1.NodeAddress{Type: v1.NodeHostName, Address: node.Name}
 	}
+
+	// Returns the hostname address anyway.
+	// Fallback: In case of error, logs the IP fetching failure but still returns the hostname.
 	getNodeAddressWithHostNameOnly := func() []v1.NodeAddress {
 		return []v1.NodeAddress{getHostNameAddress()}
 	}

--- a/pkg/cloud-controller-manager/instance_ip.go
+++ b/pkg/cloud-controller-manager/instance_ip.go
@@ -225,12 +225,25 @@ func categorizeByProvidedIP(addrs []netip.Addr, providedIP string) CandidateAddr
 
 func categorizeByCIDR(addrs []netip.Addr, prefixes []netip.Prefix) CandidateAddresses {
 	res := make(CandidateAddresses, 0, len(addrs))
+	// The first IPv4 address and the first IPv6 address that match any prefix are marked as InternalIP.
+	// This avoids misclassifying additional addresses (for example, load balancer VIPs) on the same subnet
+	// as InternalIP when they are bound to the target network (for example, the mgmt network).
+	hasInternalIPv4, hasInternalIPv6 := false, false
 	for _, addr := range addrs {
 		ipType := v1.NodeExternalIP
-		for _, pfx := range prefixes {
-			if pfx.Contains(addr) {
-				ipType = v1.NodeInternalIP
-				break
+		isV4 := addr.Is4()
+		needsInternal := (isV4 && !hasInternalIPv4) || (!isV4 && !hasInternalIPv6)
+		if needsInternal {
+			for _, pfx := range prefixes {
+				if pfx.Contains(addr) {
+					ipType = v1.NodeInternalIP
+					if isV4 {
+						hasInternalIPv4 = true
+					} else {
+						hasInternalIPv6 = true
+					}
+					break
+				}
 			}
 		}
 		res = append(res, CandidateAddress{
@@ -270,6 +283,11 @@ func categorizeByFallback(addrs []netip.Addr) CandidateAddresses {
 func filterByCIDRPolicy(addrs CandidateAddresses, prefixes []netip.Prefix) CandidateAddresses {
 	final := make(CandidateAddresses, 0, len(addrs))
 	for _, ca := range addrs {
+		if ca.NodeAddr.Type == v1.NodeInternalIP {
+			final = append(final, ca)
+			continue
+		}
+		// only filter ExternalIP
 		match := false
 		for _, pfx := range prefixes {
 			if pfx.Contains(ca.Addr) {

--- a/pkg/cloud-controller-manager/instance_test.go
+++ b/pkg/cloud-controller-manager/instance_test.go
@@ -140,6 +140,69 @@ func Test_getNodeAddresses(t *testing.T) {
 			},
 		},
 		{
+			name: "Priority 1: Failure: Invalid Annotation (Strict Mode - mismatch results in all IPs being marked as ExternalIP; no InternalIP)",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						// key: "alpha.kubernetes.io/provided-node-ip",
+						api.AnnotationAlphaProvidedIPAddr: "invalid-ip-string",
+					},
+				},
+			},
+			vmi: stubMultusVMI(nic0, "mgmt", []string{network120IP, networkDefault100IP}),
+			output: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: network120IP},
+				{Type: v1.NodeExternalIP, Address: networkDefault100IP},
+				{Type: v1.NodeHostName, Address: nodeName},
+			},
+		},
+
+		{
+			name:        "Priority 2: CIDR Mode (Strict Filtering), exclude via IP",
+			cidrRanges:  subnet130,
+			excludeList: []string{network130IPStorage},
+			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			vmi:         stubMultusVMI(nic0, "any/net", []string{network130IP, network130IPStorage}),
+			output: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: network130IP},
+				// {Type: v1.NodeExternalIP, Address: network130IPStorage}, // filtered from external
+				{Type: v1.NodeHostName, Address: nodeName},
+			},
+		},
+		{
+			name:        "Priority 2: CIDR Mode, exclude via IP prefix",
+			excludeList: []string{"192.168.0.0/16"},
+			cidrRanges:  "192.168.0.0/16",
+			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			vmi:         stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP, network120IP, network130IP, network130IPStorage}),
+			output: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: networkDefault100IP}, // only first is marked and others are filtered
+				{Type: v1.NodeHostName, Address: nodeName},
+			},
+		},
+		{
+			name:       "Priority 2: CIDR Mode, node ip CIDR mismatch, all available IPs are marked as external",
+			cidrRanges: subnet200,
+			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			vmi:        stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP, network120IP}),
+			output: []v1.NodeAddress{
+				{Type: v1.NodeExternalIP, Address: networkDefault100IP},
+				{Type: v1.NodeExternalIP, Address: network120IP},
+				{Type: v1.NodeHostName, Address: nodeName},
+			},
+		},
+		{
+			name: "Priority 3: Fallback Discovery (Dual Stack)",
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			vmi:  stubMultusVMI(nic0, "default/none", []string{networkDefault100IP, "fd00::1"}),
+			output: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: networkDefault100IP},
+				{Type: v1.NodeInternalIP, Address: "fd00::1"},
+				{Type: v1.NodeHostName, Address: nodeName},
+			},
+		},
+		{
 			name:              "Priority 3: Logic: Exclusion via Node Annotation (Fallback Mode)",
 			managementNetwork: mgmtNetwork,
 			node: &v1.Node{
@@ -155,91 +218,6 @@ func Test_getNodeAddresses(t *testing.T) {
 			output: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: networkDefault100IP},
 				// `network120IP` is excluded from InternalIP and ExternalIP
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name:       "Priority 2: CIDR Mode (Strict Filtering)",
-			cidrRanges: subnet130,
-			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:        stubMultusVMI(nic0, "any/net", []string{networkDefault100IP, network130IP}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: networkDefault100IP},
-				{Type: v1.NodeInternalIP, Address: network130IP},
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name:        "Priority 2: CIDR Mode (Strict Filtering), storage ip is also in node ip subnet which is filtered",
-			cidrRanges:  subnet130,
-			excludeList: []string{network130IPStorage},
-			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:         stubMultusVMI(nic0, "any/net", []string{network130IP, network130IPStorage}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: network130IP},
-				// {Type: v1.NodeInternalIP, Address: network130IPStorage}, // filtered from internal
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name:        "Priority 2: CIDR Mode (Strict Filtering), exclude a sub group from cidr range",
-			excludeList: []string{network120IP}, // a sub group of following cidr range
-			cidrRanges:  "192.168.0.0/16",
-			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:         stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP, network120IP}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: networkDefault100IP},
-				// {Type: v1.NodeInternalIP, Address: network120IP}, // filtered from internal
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name: "Priority 3: Fallback Discovery (Dual Stack)",
-			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:  stubMultusVMI(nic0, "default/none", []string{networkDefault100IP, "fd00::1"}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: networkDefault100IP},
-				{Type: v1.NodeInternalIP, Address: "fd00::1"},
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name: "Failure: Invalid Annotation (Strict Mode - Mismatch results in all IPs are marked as ExternalIP, no InternalIP)",
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-					Annotations: map[string]string{
-						// key: "alpha.kubernetes.io/provided-node-ip",
-						api.AnnotationAlphaProvidedIPAddr: "invalid-ip-string",
-					},
-				},
-			},
-			vmi: stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: networkDefault100IP},
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name:        "Offensive: node exclude list is so big that it excludes all available IPs",
-			excludeList: []string{"192.168.0.0/16"},
-			cidrRanges:  "192.168.0.0/16",
-			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:         stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP, network120IP}),
-			output: []v1.NodeAddress{
-				// {Type: v1.NodeExternalIP, Address: networkDefault100IP},
-				// {Type: v1.NodeExternalIP, Address: network120IP},
-				{Type: v1.NodeHostName, Address: nodeName},
-			},
-		},
-		{
-			name:       "Mismatch: node ip CIDR mismatch, all available IPs are marked as external",
-			cidrRanges: subnet200,
-			node:       &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
-			vmi:        stubMultusVMI(nic0, "mgmt", []string{networkDefault100IP, network120IP}),
-			output: []v1.NodeAddress{
-				{Type: v1.NodeExternalIP, Address: networkDefault100IP},
-				{Type: v1.NodeExternalIP, Address: network120IP},
 				{Type: v1.NodeHostName, Address: nodeName},
 			},
 		},
@@ -449,6 +427,9 @@ func Test_resolveNodeIPs(t *testing.T) {
 		v4Prefix = netip.MustParsePrefix("10.0.0.0/24")
 		v6Prefix = netip.MustParsePrefix("fd00::/64")
 
+		v4Addr1Prefix = netip.MustParsePrefix(v4Str1 + "/32")
+		v4Addr2Prefix = netip.MustParsePrefix(v4Str2 + "/32")
+
 		v4PrefixList  = []netip.Prefix{v4Prefix}
 		dualStackList = []netip.Prefix{v4Prefix, v6Prefix}
 	)
@@ -486,7 +467,37 @@ func Test_resolveNodeIPs(t *testing.T) {
 			},
 			expected: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: v4Str1},
-				{Type: v1.NodeInternalIP, Address: v4Str2},
+				{Type: v1.NodeExternalIP, Address: v4Str2}, // second IP on the same CIDR is still treated as external
+				{Type: v1.NodeInternalIP, Address: v6Str1},
+				{Type: v1.NodeExternalIP, Address: extStr1},
+			},
+		},
+		{
+			name: "Priority 2: ModeNodeIPCIDR (Multi-IP Policy), filter v4addr2",
+			ips:  []netip.Addr{v4addr1, v4addr2, v6addr, extAddr},
+			ctx: AddressContext{
+				Mode:                  ModeNodeIPCIDR,
+				NodeIPCIDRPrefixes:    dualStackList,
+				NodeExcludeIPPrefixes: []netip.Prefix{v4Addr2Prefix},
+			},
+			expected: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: v4Str1},
+				// {Type: v1.NodeExternalIP, Address: v4Str2}, // second IP is not exposed
+				{Type: v1.NodeInternalIP, Address: v6Str1},
+				{Type: v1.NodeExternalIP, Address: extStr1},
+			},
+		},
+		{
+			name: "Priority 2: ModeNodeIPCIDR (Multi-IP Policy), cannot filter internalIP v4addr1",
+			ips:  []netip.Addr{v4addr1, v4addr2, v6addr, extAddr},
+			ctx: AddressContext{
+				Mode:                  ModeNodeIPCIDR,
+				NodeIPCIDRPrefixes:    dualStackList,
+				NodeExcludeIPPrefixes: []netip.Prefix{v4Addr1Prefix},
+			},
+			expected: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: v4Str1}, // cannot filter internal IP
+				{Type: v1.NodeExternalIP, Address: v4Str2},
 				{Type: v1.NodeInternalIP, Address: v6Str1},
 				{Type: v1.NodeExternalIP, Address: extStr1},
 			},


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

On guest cluster, the LB IP is binded to first/mgmt network by default, and it could be exposed as `InternalIP` if `--node-ip-cidr` is set.

This differs with legacy.

In most cases, report at most one IPv4 and one IPv6 as InternalIP to k8s node, is the safe way.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Minor tweak after https://github.com/harvester/cloud-provider-harvester/pull/74 is merged.

1. Only pick the first valid IPv4, IPv6 (after matching with `--node-ip-cidr`) as `InternalIP`.
2. Filter `node-exclude-ip-ranges` only upon `ExternalIP`, this is used to `hide` some IPs to be exposed on k8s node object. e.g. the additional IP for storage SAN usage.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10381

#### Test plan:
<!-- Describe the test plan by steps. -->

In below test output, the guest cluster is IPv4-only, but the node is booted with dual-IPs (192.168.122.237, 2001:db8:cafe::1fe/128) via KVM DHCP server;  the node has also one LB service VIP (192.168.122.5)

The HCP needs to report those IPs precisely per configuration params  `--node-ip-cidr` and `node-exclude-ip-ranges`

```
2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether e6:24:7b:38:ed:c6 brd ff:ff:ff:ff:ff:ff
    inet 192.168.122.237/24 metric 100 brd 192.168.122.255 scope global dynamic enp1s0
       valid_lft 2042sec preferred_lft 2042sec
    inet 192.168.122.5/32 scope global enp1s0
       valid_lft forever preferred_lft forever
    inet6 2001:db8:cafe::1fe/128 scope global dynamic noprefixroute 
       valid_lft 76596sec preferred_lft 76596sec
    inet6 fe80::e424:7bff:fe38:edc6/64 scope link 
       valid_lft forever preferred_lft forever
```



**A. Default behaviour (no change)**

1. Setup guest cluster
2. Create LB services to get VIP on guest cluster
3. Check the reported IPs on k8s node object

It only reports the valid first IPv4, IPv6 as node IP, the VIP is marked as ExternalIP

```
time="2026-06-18T07:57:35Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc3 --controllers=* --management-network= 
--node-ip-cidr= --node-exclude-ip-ranges= --disable-annotation-alpha-provided-ip-addr=false --disable-vmi-controller=false --show-full-help-on-error=false"

time="2026-06-18T08:03:09Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc3-node1 via its VMI gc-test/gc3-node1 on network nic-0: 

[{InternalIP 192.168.122.237} {ExternalIP 192.168.122.5} {InternalIP 2001:db8:cafe::1fe} {Hostname gc3-node1}]"

```

**B. Set `--node-ip-cidr`.**

1. Setup guest cluster with `--node-ip-cidr`, which is the guest node IP CIDR
2. Create LB services to get VIP on guest cluster
3. Check the reported IPs on k8s node object

Before this PR: VIP is reported as `internal`

```
time="2026-06-18T09:55:56Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc3 --controllers=* --management-network= 
--node-ip-cidr=192.168.122.0/24 --node-exclude-ip-ranges= --disable-annotation-alpha-provided-ip-addr=false --disable-vmi-controller=false --show-full-help-on-error=false"

time="2026-06-18T09:56:12Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc3-node1 via its VMI gc-test/gc3-node1 on network nic-0: 

[{InternalIP 192.168.122.237} {InternalIP 192.168.122.5} {ExternalIP 2001:db8:cafe::1fe} {Hostname gc3-node1}]"
```


With this PR: NodeIP is reported as internal; VIP is reported as external. both are expected.

```

time="2026-06-18T10:07:52Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc3 --controllers=* --management-network= --node-ip-cidr=192.168.122.0/24 --node-exclude-ip-ranges= --disable-annotation-alpha-provided-ip-addr=false --disable-vmi-controller=false --show-full-help-on-error=false"


time="2026-06-18T10:08:10Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc3-node1 via its VMI gc-test/gc3-node1 on network nic-0: 

[{InternalIP 192.168.122.237} {ExternalIP 192.168.122.5} {ExternalIP 2001:db8:cafe::1fe} {Hostname gc3-node1}]"


```


**C. Filter out some IPs**

1. Setup guest cluster with `--node-ip-cidr` and `node-exclude-ip-ranges` (to filter VIP)  (those two must be set together, `node-exclude-ip-ranges` is only used when `--node-ip-cidr` is set )
2. Create LB services to get VIP on guest cluster
3. Check the reported IPs on k8s node object


Before this PR: Both node IP (unexpected) and VIP (expected) are filtered out.
```
time="2026-06-18T10:01:13Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc3 --controllers=* --management-network= 
--node-ip-cidr=192.168.122.0/24 --node-exclude-ip-ranges=192.168.122.0/24 --disable-annotation-alpha-provided-ip-addr=false --disable-vmi-controller=false --show-full-help-on-error=false"

time="2026-06-18T10:01:31Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc3-node1 via its VMI gc-test/gc3-node1 on network nic-0: 

[{ExternalIP 2001:db8:cafe::1fe} {Hostname gc3-node1}]"
```

With this PR: node-ip is not filtered; VIP is filtered. both are expected.

```
time="2026-06-18T10:04:25Z" level=info msg="cloudprovider.harvesterhci.io effective configurations: --cluster-name=gc3 --controllers=* --management-network= 
--node-ip-cidr=192.168.122.0/24 --node-exclude-ip-ranges=192.168.122.0/24 --disable-annotation-alpha-provided-ip-addr=false --disable-vmi-controller=false --show-full-help-on-error=false"

time="2026-06-18T10:04:43Z" level=info msg="Successfully resolved (fetched, checked and filtered) addresses for node gc3-node1 via its VMI gc-test/gc3-node1 on network nic-0: 

[{InternalIP 192.168.122.237} {ExternalIP 2001:db8:cafe::1fe} {Hostname gc3-node1}]"
```


#### Additional documentation or context
