### PR TITLE
fix: ensure network annotation consistency in LoadBalancer service updates

### DIFF
--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -185,6 +185,10 @@ func (l *LoadBalancerManager) EnsureLoadBalancer(ctx context.Context, clusterNam
 func (l *LoadBalancerManager) ensurePrimaryLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, error) {
 	name := loadBalancerName(clusterName, service.Namespace, service.Name, string(service.UID))
 
+	if err := l.checkNetworkChanged(service, name, false); err != nil {
+		return nil, err
+	}
+
 	if err := l.createOrUpdateLoadBalancer(name, clusterName, service); err != nil {
 		return nil, fmt.Errorf("create or update lb %s/%s failed, error: %w", l.namespace, name, err)
 	}
@@ -211,6 +215,12 @@ func (l *LoadBalancerManager) ensureSecondaryLoadBalancer(clusterName string, pr
 		return nil, fmt.Errorf("check port overlap failed, primary service: %s/%s, secondary service: %s/%s, error: %w",
 			primary.Namespace, primary.Name, secondary.Namespace, secondary.Name, err)
 	}
+
+	primaryLBName := loadBalancerName(clusterName, primary.Namespace, primary.Name, string(primary.UID))
+	if err := l.checkNetworkChanged(secondary, primaryLBName, true); err != nil {
+		return nil, err
+	}
+
 	// delete the original load balancer if existing
 	if err := l.deleteLoadBalancer(clusterName, secondary); err != nil {
 		return nil, err
@@ -328,7 +338,17 @@ func (l *LoadBalancerManager) constructLB(oldLB *lbv1.LoadBalancer, service *v1.
 	if lb.Annotations == nil {
 		lb.Annotations = make(map[string]string)
 	}
-	lb.Annotations[pkgctllb.AnnotationKeyNetwork] = service.Annotations[utils.KeyNetwork]
+
+	if oldLB == nil || oldLB.Name == "" {
+		// if lb exists, doesn't overwrite the network annotation again
+		// we should use network from the lb directly
+		// because we don't allow network to be changed.
+		lb.Annotations[pkgctllb.AnnotationKeyNetwork] = service.Annotations[utils.KeyNetwork]
+
+		// keep original network request from the service at the first time if it presents, and don't overwrite it again if lb exists
+		lb.Annotations[utils.AnnotationKeyNetworkOnLB] = service.Annotations[utils.KeyNetwork]
+	}
+
 	lb.Annotations[pkgctllb.AnnotationKeyProject] = service.Annotations[utils.KeyProject]
 	lb.Annotations[pkgctllb.AnnotationKeyNamespace] = service.Annotations[utils.KeyNamespace]
 	lb.Annotations[pkgctllb.AnnotationKeyCluster] = clusterName
@@ -383,7 +403,7 @@ func (l *LoadBalancerManager) retryUpdateService(service *v1.Service, serviceTyp
 	return nil
 }
 
-func isPrimaryServiceUpdatedWithIP(service *v1.Service, lbAddress, ip, resolvedIface string) bool {
+func isPrimaryServiceUpdatedWithIP(service *v1.Service, lb *lbv1.LoadBalancer, ip, resolvedIface string) bool {
 	if resolvedIface != "" && service.Annotations[utils.KeyKubevipServiceInterface] != resolvedIface {
 		return false
 	}
@@ -392,7 +412,7 @@ func isPrimaryServiceUpdatedWithIP(service *v1.Service, lbAddress, ip, resolvedI
 	// check the IP and let the serviceInterface annotation remain as-is.
 	return service.Annotations != nil &&
 		service.Annotations[utils.KeyKubevipLoadBalancerIP] == ip &&
-		lbAddress == ip &&
+		lb.Status.Address == ip &&
 		service.Labels != nil &&
 		service.Labels[utils.KeyPrimaryService] == ""
 }
@@ -422,7 +442,8 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 	}
 
 	lb := object.(*lbv1.LoadBalancer)
-	if isPrimaryServiceUpdatedWithIP(service, lb.Status.Address, ip, resolvedIface) {
+
+	if isPrimaryServiceUpdatedWithIP(service, lb, ip, resolvedIface) {
 		return nil
 	}
 
@@ -434,7 +455,6 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 			serviceCopy.Annotations = make(map[string]string)
 		}
 		serviceCopy.Annotations[utils.KeyKubevipLoadBalancerIP] = ip
-
 		if resolvedIface != "" {
 			serviceCopy.Annotations[utils.KeyKubevipServiceInterface] = resolvedIface
 		}
@@ -445,7 +465,16 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 	return l.retryUpdateService(service, "primary", ip, "", updatePrimaryServiceObject)
 }
 
-func isSecondaryServiceUpdatedWithPrimary(secondary *v1.Service, ip, labelValue string) bool {
+func isSecondaryServiceUpdatedWithPrimary(primary, secondary *v1.Service, ip, labelValue string) bool {
+
+	// old dhcp svc doesn't have network annotation.
+	if hasNetworkAnnotation(primary) {
+		// the network from secondary should be same as primary, we don't allow users to change network annotation in svc
+		if secondary.Annotations[utils.KeyNetwork] != primary.Annotations[utils.KeyNetwork] {
+			return false
+		}
+	}
+
 	return secondary.Annotations != nil &&
 		secondary.Annotations[utils.KeyKubevipLoadBalancerIP] == ip &&
 		secondary.Annotations[utils.KeyKubevipServiceInterface] == "" &&
@@ -456,7 +485,7 @@ func isSecondaryServiceUpdatedWithPrimary(secondary *v1.Service, ip, labelValue 
 
 func (l *LoadBalancerManager) updateSecondaryServiceLoadBalancerIP(ip string, primary, secondary *v1.Service) error {
 	labelValue := primaryServiceLabelValue(primary)
-	if isSecondaryServiceUpdatedWithPrimary(secondary, ip, labelValue) {
+	if isSecondaryServiceUpdatedWithPrimary(primary, secondary, ip, labelValue) {
 		return nil
 	}
 
@@ -471,11 +500,53 @@ func (l *LoadBalancerManager) updateSecondaryServiceLoadBalancerIP(ip string, pr
 		secondaryCopy.Labels[utils.KeyPrimaryService] = primaryLabel
 		// update the annotations and kube-vip will update the service status load balancer
 		secondaryCopy.Annotations[utils.KeyKubevipLoadBalancerIP] = ip
+
+		// old dhcp svc doesn't have network annotation.
+		if hasNetworkAnnotation(primary) {
+			secondaryCopy.Annotations[utils.KeyNetwork] = primary.Annotations[utils.KeyNetwork]
+		}
+
 		delete(secondaryCopy.Annotations, utils.KeyKubevipServiceInterface)
 		delete(secondaryCopy.Annotations, utils.KeyIPAM)
 	}
 
 	return l.retryUpdateService(secondary, "secondary", ip, labelValue, updateSecondaryServiceObject)
+}
+
+func hasNetworkAnnotation(service *v1.Service) bool {
+	return service.Annotations[utils.KeyNetwork] != ""
+}
+
+func IsNetworkChanged(svc *v1.Service, lb *lbv1.LoadBalancer) bool {
+	return svc.Annotations[utils.KeyNetwork] != lb.Annotations[utils.AnnotationKeyNetworkOnLB]
+}
+
+func (l *LoadBalancerManager) checkNetworkChanged(svc *v1.Service, lbName string, secondary bool) error {
+	lb, err := l.lbClient.Get(l.namespace, lbName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if lb == nil || lb.Name == "" {
+		return nil
+	}
+
+	if secondary {
+		if svc.Annotations[utils.KeyNetwork] == "" && lb.Annotations[utils.AnnotationKeyNetworkOnLB] != "" {
+			// skip the check
+			// because secondary service doesn't have network annotation yet
+			// we need to sync from the primay service
+			return nil
+		}
+	}
+
+	// // Don't allow users to change network annotation in svc for existed load balancer.
+	if IsNetworkChanged(svc, lb) {
+		return fmt.Errorf("network annotation of service %s/%s is not same as the load balancer %s/%s, service: '%s', lb: '%s'",
+			svc.Namespace, svc.Name, lb.Namespace, lb.Name, svc.Annotations[utils.KeyNetwork], lb.Annotations[pkgctllb.AnnotationKeyNetwork])
+	}
+
+	return nil
 }
 
 func (l *LoadBalancerManager) deleteLoadBalancer(clusterName string, service *v1.Service) error {

--- a/pkg/cloud-controller-manager/loadbalancer.go
+++ b/pkg/cloud-controller-manager/loadbalancer.go
@@ -467,7 +467,7 @@ func (l *LoadBalancerManager) updatePrimaryServiceLoadBalancerIP(lbName string, 
 
 func isSecondaryServiceUpdatedWithPrimary(primary, secondary *v1.Service, ip, labelValue string) bool {
 
-	// old dhcp svc doesn't have network annotation.
+	// old svc doesn't have network annotation.
 	if hasNetworkAnnotation(primary) {
 		// the network from secondary should be same as primary, we don't allow users to change network annotation in svc
 		if secondary.Annotations[utils.KeyNetwork] != primary.Annotations[utils.KeyNetwork] {
@@ -501,7 +501,7 @@ func (l *LoadBalancerManager) updateSecondaryServiceLoadBalancerIP(ip string, pr
 		// update the annotations and kube-vip will update the service status load balancer
 		secondaryCopy.Annotations[utils.KeyKubevipLoadBalancerIP] = ip
 
-		// old dhcp svc doesn't have network annotation.
+		// old svc doesn't have network annotation.
 		if hasNetworkAnnotation(primary) {
 			secondaryCopy.Annotations[utils.KeyNetwork] = primary.Annotations[utils.KeyNetwork]
 		}
@@ -543,7 +543,7 @@ func (l *LoadBalancerManager) checkNetworkChanged(svc *v1.Service, lbName string
 	// // Don't allow users to change network annotation in svc for existed load balancer.
 	if IsNetworkChanged(svc, lb) {
 		return fmt.Errorf("network annotation of service %s/%s is not same as the load balancer %s/%s, service: '%s', lb: '%s'",
-			svc.Namespace, svc.Name, lb.Namespace, lb.Name, svc.Annotations[utils.KeyNetwork], lb.Annotations[pkgctllb.AnnotationKeyNetwork])
+			svc.Namespace, svc.Name, lb.Namespace, lb.Name, svc.Annotations[utils.KeyNetwork], lb.Annotations[utils.AnnotationKeyNetworkOnLB])
 	}
 
 	return nil

--- a/pkg/cloud-controller-manager/loadbalancer_test.go
+++ b/pkg/cloud-controller-manager/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+	pkgctllb "github.com/harvester/harvester-load-balancer/pkg/controller/loadbalancer"
 	"github.com/sirupsen/logrus/hooks/test"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,6 +118,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 		annotations   map[string]string
 		labels        map[string]string
 		lbAddress     string
+		lbNetwork     string
 		ip            string
 		resolvedIface string
 		want          bool
@@ -164,6 +166,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 			},
 			labels:        map[string]string{utils.KeyPrimaryService: ""},
 			lbAddress:     ip,
+			lbNetwork:     "default/mgmt-vlan1",
 			ip:            ip,
 			resolvedIface: "enp1s0",
 			want:          false,
@@ -179,6 +182,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 			},
 			labels:    map[string]string{utils.KeyPrimaryService: ""},
 			lbAddress: ip,
+			lbNetwork: "default/mgmt-vlan1",
 			ip:        ip,
 			// resolvedIface left empty (zero value) — mapping unavailable
 			want: true,
@@ -210,6 +214,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 			},
 			labels:        map[string]string{utils.KeyPrimaryService: ""},
 			lbAddress:     ip,
+			lbNetwork:     "default/mgmt-vlan1",
 			ip:            ip,
 			resolvedIface: "enp1s0",
 			want:          true,
@@ -238,6 +243,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 			},
 			labels:        map[string]string{utils.KeyPrimaryService: ""},
 			lbAddress:     ip,
+			lbNetwork:     "default/mgmt-vlan1",
 			ip:            ip,
 			resolvedIface: "enp1s0",
 			want:          false,
@@ -253,6 +259,7 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 			},
 			labels:        map[string]string{utils.KeyPrimaryService: ""},
 			lbAddress:     ip,
+			lbNetwork:     "default/mgmt-vlan1",
 			ip:            ip,
 			resolvedIface: "enp1s0",
 			want:          true,
@@ -262,7 +269,17 @@ func Test_isPrimaryServiceUpdatedWithIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := newServiceWithAnnotations(tt.annotations, tt.labels)
-			got := isPrimaryServiceUpdatedWithIP(svc, tt.lbAddress, tt.ip, tt.resolvedIface)
+			lb := &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						pkgctllb.AnnotationKeyNetwork: tt.lbNetwork,
+					},
+				},
+				Status: lbv1.LoadBalancerStatus{
+					Address: tt.lbAddress,
+				},
+			}
+			got := isPrimaryServiceUpdatedWithIP(svc, lb, tt.ip, tt.resolvedIface)
 			if got != tt.want {
 				t.Errorf("isPrimaryServiceUpdatedWithIP() = %v, want %v", got, tt.want)
 			}
@@ -407,7 +424,8 @@ func Test_isSecondaryServiceUpdatedWithPrimary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := newServiceWithAnnotations(tt.annotations, tt.labels)
-			got := isSecondaryServiceUpdatedWithPrimary(svc, ip, labelValue)
+			primary := newServiceWithAnnotations(nil, nil)
+			got := isSecondaryServiceUpdatedWithPrimary(primary, svc, ip, labelValue)
 			if got != tt.want {
 				t.Errorf("isSecondaryServiceUpdatedWithPrimary() = %v, want %v", got, tt.want)
 			}

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -55,6 +55,11 @@ const (
 	// value format: `default/vlan100`
 	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
 
+	// AnnotationKeyNetworkOnLB stores the raw network name (namespace/name format, e.g. "default/net123")
+	// on the LoadBalancer object. This replaces the label-based approach (utils.KeyNetwork label)
+	// which required sanitizing '/' to '_' because label values cannot contain slashes.
+	AnnotationKeyNetworkOnLB = HarvesterCloudProviderPrefix + "lb-network"
+
 	// cloud-provider framework injects `kubernetes` as cluster-name when runtime env `--cluster-name` is not set
 	// if `--cluster-name=abc` then `cluster-name` is `abc`
 	// if `--cluster-name=` then `cluster-name` is `` (empty)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:

> (1) On loadbalancer-harvester or HCP, deny the network annotation change; when a service&LB has already allocated IP, change the network, does not trigger IP reallocation and kube-vip interface rebinding, hence block this change is essential.
> 
> (2) For HCP secondary/primary service, ensure the secondary service to have same network annotation as primary; let service from different network share IP is an error case. This is not an issue in the past, but after this PR, a check is needed.

In old flow:
dhcp & ippool no network annotation in svc

in new flow:
dhcp & ippool have network annotation in svc

#### Solution:

So, if svc contains a network annotation, while users try to modify network annotation, we'll use network annotation from existed lb resource to compare to ensure that users can't change the network annotation after they create svc. 

The flow looks likes:

1. user creates a svc with network default/net123 
2. lb is created and attached an network annotation (default/net123)
3. user tries to modify the network annotation to default/mgmt-vlan1
4. backend compare the network annotation from the svc and the lb
5. backend forces the value to be the same.

Secondary svc also uses similar method which uses network annotation from primary network.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5486

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
