### PR TITLE
Inject proper version info to ccm framework

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -30,6 +30,11 @@ jobs:
 
     - name: Run dapper
       run: make ci
+      env:
+        # Pass the inputs down to the Makefile and scripts/version on the host
+        TAG: ${{ inputs.tag }}
+        GIT_TAG: ${{ inputs.tag }}
+        VERSION: ${{ inputs.tag }}
 
     - name: Read some Secrets
       uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ test: gen-version-env
 
 
 # ---- Package image ----
+# Simulate a GitHub Actions release or RC locally:
+#   TAG="v0.2.8" GIT_TAG="v0.2.8" make package
+#   TAG="v0.2.8-rc1" GIT_TAG="v0.2.8-rc1" make package
 package: build
 	$(BANNER)
 	$(ROOT)/scripts/package
@@ -116,6 +119,14 @@ clean-all:
 
 .DEFAULT_GOAL := default
 
+# Export release and version overrides to all child targets and sub-shells
+export TAG
+export GIT_TAG
+export VERSION
+
+# Simulate a GitHub Actions release or RC locally:
+#   TAG="v0.2.8" GIT_TAG="v0.2.8" make ci
+#   TAG="v0.2.8-rc1" GIT_TAG="v0.2.8-rc1" make ci
 ci: build test validate package
 
 default: build package

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -13,6 +14,7 @@ import (
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
 	ccm "github.com/harvester/harvester-cloud-provider/pkg/cloud-controller-manager"
@@ -22,6 +24,7 @@ import (
 
 func main() {
 	utils.BootstrapLogrus()
+	printFrameworkVersion()
 
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
@@ -146,4 +149,16 @@ func registerHarvesterFlags(harv *pflag.FlagSet) {
 
 	harv.BoolVar(&config.ShowFullHelpOnError, utils.FlagShowFullHelpOnError, false,
 		"If a configuration error occurs at startup, the full help menu and flag list will be displayed. (default false)")
+}
+
+func printFrameworkVersion() {
+	info := version.Get()
+
+	marshaled, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		klog.Errorf("Failed to marshal framework version info: %v", err)
+		return
+	}
+
+	klog.Infof("CCM framework version:\n%s", string(marshaled))
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 
 func main() {
 	utils.BootstrapLogrus()
-	printFrameworkVersion()
 
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
@@ -73,6 +72,8 @@ func main() {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	logFrameworkVersion()
 
 	// Wrap the framework's RunE with our custom configuration sync and validation
 	originalRunE := command.RunE
@@ -151,14 +152,17 @@ func registerHarvesterFlags(harv *pflag.FlagSet) {
 		"If a configuration error occurs at startup, the full help menu and flag list will be displayed. (default false)")
 }
 
-func printFrameworkVersion() {
+// logFrameworkVersion logs the detailed version structure as a single-line JSON payload.
+// This provides full version metadata for easier debugging, whereas the CCM framework by
+// default only outputs minimal info like "controllermanager.go:160] Version: v0.0.0-63c5e714".
+func logFrameworkVersion() {
 	info := version.Get()
 
-	marshaled, err := json.MarshalIndent(info, "", "  ")
+	marshaled, err := json.Marshal(info)
 	if err != nil {
-		klog.Errorf("Failed to marshal framework version info: %v", err)
+		klog.Errorf("Failed to marshal framework version: %v", err)
 		return
 	}
 
-	klog.Infof("CCM framework version:\n%s", string(marshaled))
+	klog.Infof("CCM framework version: %s", string(marshaled))
 }

--- a/scripts/build
+++ b/scripts/build
@@ -8,6 +8,50 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
+# version info for `func Get() apimachineryversion.Info `
+PKG="k8s.io/component-base/version"
+
+# Deduce gitTreeState strictly from DIRTY set by scripts/version
+if [ -n "${DIRTY}" ]; then
+    GIT_TREE_STATE="dirty"
+else
+    GIT_TREE_STATE="clean"
+fi
+
+# Format GIT_VERSION to satisfy k8s semver requirements
+GIT_VERSION="${VERSION:-v0.0.0-unknown}"
+if [[ ! "${GIT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    GIT_VERSION="v0.0.0-${GIT_VERSION}"
+fi
+
+# Fall back buildDate to current UTC time; use epoch if the date tool is unavailable
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "1970-01-01T00:00:00Z")
+
+# Full SHA for gitCommit
+GIT_COMMIT="${COMMIT_FULL:-${COMMIT:-00000000}}"
+# Extract Major and Minor version numbers
+GIT_MAJOR="0"
+GIT_MINOR="0"
+if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
+    GIT_MAJOR="${BASH_REMATCH[1]}"
+    GIT_MINOR="${BASH_REMATCH[2]}"
+fi
+
+# Construct version ldflags
+LDFLAGS_VERSION=(
+    "-X ${PKG}.gitVersion=${GIT_VERSION}"
+    "-X ${PKG}.gitCommit=${GIT_COMMIT}"
+    "-X ${PKG}.gitTreeState=${GIT_TREE_STATE}"
+    "-X ${PKG}.buildDate=${BUILD_DATE}"
+    "-X ${PKG}.gitMajor=${GIT_MAJOR}"
+    "-X ${PKG}.gitMinor=${GIT_MINOR}"
+)
+
+ALL_LDFLAGS="${LDFLAGS_VERSION[*]} ${LINKFLAGS:-}"
+
+echo "To be injected version info:"
+echo "${LDFLAGS_VERSION[*]}"
+
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-cloud-provider-"$arch"
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "${ALL_LDFLAGS}" -o bin/harvester-cloud-provider-"$arch"
 done

--- a/scripts/version
+++ b/scripts/version
@@ -31,16 +31,29 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
 fi
 
-COMMIT=$(git -C "${TOP_DIR}" rev-parse --short=8 HEAD)
+COMMIT=$(git -C "${TOP_DIR}" rev-parse --short=8 HEAD 2>/dev/null || echo "00000000")
+COMMIT_FULL=$(git -C "${TOP_DIR}" rev-parse HEAD 2>/dev/null || echo "${COMMIT}")
 COMMIT_BRANCH=$(git -C "${TOP_DIR}" rev-parse --abbrev-ref HEAD)
 COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9.]+/-/g')
-GIT_TAG=$(git -C "${TOP_DIR}" tag -l --contains HEAD | head -n 1)
+
+# Prefer GIT_TAG from environment if set (e.g. GitHub Workflow or Make),
+# otherwise resolve from live git repository.
+# TAG is primarily used as an image tag and may include arch suffixes, so don't use it as a git tag fallback.
+if [[ -n "${GIT_TAG}" ]]; then
+    echo "Info: using GIT_TAG from environment: ${GIT_TAG}"
+else
+    GIT_TAG="$(git -C "${TOP_DIR}" tag -l --contains HEAD 2>/dev/null | head -n 1)"
+fi
+
 if [[ "$GIT_TAG" == *"-dev-"* ]]; then
     SPRINT_RELEASE="-dev-"
 fi
 
-if [[ -z "$DIRTY" && -n "$GIT_TAG" && -z "$SPRINT_RELEASE" ]]; then
-    VERSION=$GIT_TAG
+# Use explicit VERSION from environment if provided, otherwise deduce from GIT_TAG or COMMIT
+if [[ -n "${VERSION}" ]]; then
+    echo "Info: using explicit VERSION override from environment: ${VERSION}"
+elif [[ -z "$DIRTY" && -n "${GIT_TAG}" && -z "$SPRINT_RELEASE" ]]; then
+    VERSION="${GIT_TAG}"
  else
     VERSION="${COMMIT}${DIRTY}"
 fi
@@ -67,6 +80,7 @@ cat > "${_VERSION_ENV}" <<__EOF__
 ARCH="${ARCH}"
 DIRTY="${DIRTY}"
 COMMIT="${COMMIT}"
+COMMIT_FULL="${COMMIT_FULL}"
 COMMIT_BRANCH="${COMMIT_BRANCH}"
 COMMIT_BRANCH_FORMATTED="${COMMIT_BRANCH_FORMATTED}"
 GIT_TAG="${GIT_TAG}"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

HCP does not print the correct version info when container runs.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add the missing info.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11563

#### Test plan:
<!-- Describe the test plan by steps. -->

Static env test:

```
TAG="v0.2.8" GIT_TAG="v0.2.8" make gen-version-env-debug
[target: gen-version-env-debug]
The newly generated envs:

ARCH="amd64"
DIRTY=""
COMMIT="c9b2a5e1"
COMMIT_BRANCH="fix-version"
COMMIT_BRANCH_FORMATTED="fix-version"
GIT_TAG="v0.2.8"
SPRINT_RELEASE=""
VERSION="v0.2.8"
IMAGE_PUSH_TAG=""
SUFFIX="-amd64"
TAG="v0.2.8"
REPO="rancher"

make gen-version-env-debug
[target: gen-version-env-debug]
The newly generated envs:

ARCH="amd64"
DIRTY=""
COMMIT="c9b2a5e1"
COMMIT_BRANCH="fix-version"
COMMIT_BRANCH_FORMATTED="fix-version"
GIT_TAG=""
SPRINT_RELEASE=""
VERSION="c9b2a5e1"
IMAGE_PUSH_TAG=""
SUFFIX="-amd64"
TAG="c9b2a5e1-amd64"
REPO="rancher"
```

`make build ` log:

```
...
#13 [build 1/1] RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-fa79e053     --mount=type=cache,target=/go/src/github.com/harvester/harvester-cloud-provider/.cache/go-build,id=harvester-go-build-fa79e053     ./scripts/build
#13 0.259 To be injected version info:
#13 0.259 -X k8s.io/component-base/version.gitVersion=v0.0.0-9c31b9b8-dirty -X k8s.io/component-base/version.gitCommit=9c31b9b8 -X k8s.io/component-base/version.gitTreeState=dirty -X k8s.io/component-base/version.buildDate=2026-09-02T08:36:54Z -X k8s.io/component-base/version.gitMajor=0 -X k8s.io/component-base/version.gitMinor=0


#13 [build 1/1] RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-fa79e053     --mount=type=cache,target=/go/src/github.com/harvester/harvester-cloud-provider/.cache/go-build,id=harvester-go-build-fa79e053     ./scripts/build
#13 0.224 To be injected version info:
#13 0.224 -X k8s.io/component-base/version.gitVersion=v0.2.8 -X k8s.io/component-base/version.gitCommit=c9b2a5e1 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.buildDate=2026-09-02T08:53:10Z -X k8s.io/component-base/version.gitMajor=0 -X k8s.io/component-base/version.gitMinor=2


```

on running cluster:

formal released version:
```
I0907 11:31:17.507203   37685 main.go:167] CCM framework version: {"major":"0","minor":"2","gitVersion":"v0.2.8","gitCommit":"7cfcbb1be1fd25182059424e02606e914d2542f3","gitTreeState":"clean","buildDate":"2026-09-07T09:29:19Z","goVersion":"go1.26.7","compiler":"gc","platform":"linux/amd64"}

...       1 controllermanager.go:160] Version: v0.2.8  // ccm framework shows
```

develop version:

```
 logs -n kube-system harvester-cloud-provider-66b8975647-q4wlj
I0907 11:17:31.447390   36024 main.go:166] CCM framework version: {"major":"0","minor":"0","gitVersion":"v0.0.0-349ad685","gitCommit":"349ad6859e65a34d4f64c214a26009f66505953c","gitTreeState":"clean","buildDate":"2026-09-07T09:17:00Z","goVersion":"go1.26.7","compiler":"gc","platform":"linux/amd64"}


...      1 controllermanager.go:160] Version: v0.0.0-349ad685 // ccm framework shows

```

ccm framework shows version info from the json value set  `gitVersion` field, e.g. `"gitVersion":"v0.2.8"` , `"gitVersion":"v0.0.0-349ad685"`

#### Additional documentation or context
